### PR TITLE
[AUT-171] - Add `onClose` event handler + resolve promise when popup closes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@authsignal/browser",
   "type": "module",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",

--- a/src/authsignal.ts
+++ b/src/authsignal.ts
@@ -76,10 +76,17 @@ export class Authsignal {
           if (event.origin === this.endpoint) {
             if (event.data === AuthsignalWindowMessage.AUTHSIGNAL_CLOSE_POPUP) {
               Popup.close();
-              resolve(true);
             }
           }
         };
+
+        Popup.on("hide", () => {
+          if (options?.onClose) {
+            options.onClose();
+          }
+
+          resolve(true);
+        });
 
         window.addEventListener("message", onMessage, false);
       });

--- a/src/authsignal.ts
+++ b/src/authsignal.ts
@@ -81,10 +81,6 @@ export class Authsignal {
         };
 
         Popup.on("hide", () => {
-          if (options?.onClose) {
-            options.onClose();
-          }
-
           resolve(true);
         });
 

--- a/src/popup-handler.ts
+++ b/src/popup-handler.ts
@@ -9,6 +9,10 @@ type PopupShowInput = {
   url: string;
 };
 
+type EventType = "show" | "hide" | "destroy" | "create";
+
+type EventHandler = (node: Element, event?: Event) => void;
+
 class PopupHandler {
   private popup: A11yDialog | null = null;
 
@@ -85,12 +89,17 @@ class PopupHandler {
     container.appendChild(content);
 
     this.popup = new A11yDialog(container);
-    this.popup.on("hide", this.destroy);
+
+    // Make sure to remove any trace of the dialog on hide
+    this.popup.on("hide", () => {
+      this.destroy();
+    });
   }
 
   destroy() {
     const dialogEl = document.querySelector(`#${CONTAINER_ID}`);
     const styleEl = document.querySelector(`#${STYLE_ID}`);
+
     if (dialogEl && styleEl) {
       document.body.removeChild(dialogEl);
       document.head.removeChild(styleEl);
@@ -103,12 +112,14 @@ class PopupHandler {
     }
 
     const iframe = document.createElement("iframe");
+
     iframe.setAttribute("name", "authsignal");
     iframe.setAttribute("title", "Authsignal multi-factor authentication");
     iframe.setAttribute("src", url);
     iframe.setAttribute("frameborder", "0");
 
     const dialogContent = document.querySelector(`#${CONTENT_ID}`);
+
     if (dialogContent) {
       dialogContent.appendChild(iframe);
     }
@@ -122,6 +133,14 @@ class PopupHandler {
     }
 
     this.popup.hide();
+  }
+
+  on(event: EventType, handler: EventHandler) {
+    if (!this.popup) {
+      throw new Error("Popup is not initialized");
+    }
+
+    this.popup.on(event, handler);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,17 @@ export type MfaInput = {
 };
 
 export type LaunchOptions = {
+  /**
+   *  How the Authsignal Prebuilt MFA page should launch.
+   *  `popup` will cause it to open in a overlay, whilst `redirect`
+   *  will trigger a full page redirect.
+   *  If no value is supplied, mode defaults to `redirect`.
+   */
   mode?: "popup" | "redirect";
+  /**
+   * If launched in a popup, this event will be triggered when the popup is closed.
+   */
+  onClose?: () => void;
 };
 
 export type AuthsignalOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,10 +16,6 @@ export type LaunchOptions = {
    *  If no value is supplied, mode defaults to `redirect`.
    */
   mode?: "popup" | "redirect";
-  /**
-   * If launched in a popup, this event will be triggered when the popup is closed.
-   */
-  onClose?: () => void;
 };
 
 export type AuthsignalOptions = {


### PR DESCRIPTION
- When using `launch` in popup mode, the promise will resolve when the popup closes.
- Also now expose an `onClose` event that fires when the popup closes.