### PR TITLE
[AUT-1497] Update iframe permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/popup-handler.ts
+++ b/src/popup-handler.ts
@@ -137,7 +137,7 @@ class PopupHandler {
     iframe.setAttribute("title", "Authsignal multi-factor authentication");
     iframe.setAttribute("src", url);
     iframe.setAttribute("frameborder", "0");
-    iframe.setAttribute("allow", "publickey-credentials-get *; clipboard-write");
+    iframe.setAttribute("allow", "publickey-credentials-get *; publickey-credentials-create *; clipboard-write");
 
     const dialogContent = document.querySelector(`#${CONTENT_ID}`);
 


### PR DESCRIPTION
Add `publickey-credentials-create *` now that it is in the spec. Currently no browser have implemented support for it however.