### PR TITLE
Set an initial popup height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/handlers/popup-handler.ts
+++ b/src/handlers/popup-handler.ts
@@ -8,6 +8,8 @@ const IFRAME_ID = "__authsignal-popup-iframe";
 
 const DEFAULT_WIDTH = "385px";
 
+const INITIAL_HEIGHT = "384px";
+
 type PopupShowInput = {
   url: string;
 };
@@ -97,6 +99,7 @@ export class PopupHandler {
         min-width: 100%;
         border-radius: inherit;
         max-height: 95vh;
+        height: ${INITIAL_HEIGHT};
       }
     `;
 


### PR DESCRIPTION
To avoid seeing a scrollbar when the popup first opens.