### PR TITLE
Make `authenticatorAttachment` configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/passkey-api-client.ts
+++ b/src/api/passkey-api-client.ts
@@ -24,11 +24,19 @@ export class PasskeyApiClient {
     this.baseUrl = baseUrl;
   }
 
-  async registrationOptions({token, userName}: RegistrationOptsRequest): Promise<RegistrationOptsResponse> {
+  async registrationOptions({
+    token,
+    userName,
+    authenticatorAttachment,
+  }: RegistrationOptsRequest): Promise<RegistrationOptsResponse> {
+    const body = Boolean(authenticatorAttachment)
+      ? {username: userName, authenticatorAttachment}
+      : {username: userName};
+
     const response = fetch(`${this.baseUrl}/client/user-authenticators/passkey/registration-options`, {
       method: "POST",
       headers: this.buildHeaders(token),
-      body: JSON.stringify({username: userName}),
+      body: JSON.stringify(body),
     });
 
     return (await response).json();

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,5 +1,6 @@
 import {
   AuthenticationResponseJSON,
+  AuthenticatorAttachment,
   PublicKeyCredentialCreationOptionsJSON,
   RegistrationResponseJSON,
 } from "@simplewebauthn/types";
@@ -7,6 +8,7 @@ import {
 export type RegistrationOptsRequest = {
   userName?: string;
   token: string;
+  authenticatorAttachment?: AuthenticatorAttachment | null;
 };
 
 export type RegistrationOptsResponse = {

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,7 +1,7 @@
 import {startAuthentication, startRegistration} from "@simplewebauthn/browser";
 
 import {PasskeyApiClient} from "./api";
-import {AuthenticationResponseJSON, RegistrationResponseJSON} from "@simplewebauthn/types";
+import {AuthenticationResponseJSON, RegistrationResponseJSON, AuthenticatorAttachment} from "@simplewebauthn/types";
 
 type PasskeyOptions = {
   baseUrl: string;
@@ -11,6 +11,7 @@ type PasskeyOptions = {
 type SignUpParams = {
   userName?: string;
   token: string;
+  authenticatorAttachment?: AuthenticatorAttachment | null;
 };
 
 export class Passkey {
@@ -21,8 +22,8 @@ export class Passkey {
     this.api = new PasskeyApiClient({baseUrl, tenantId});
   }
 
-  async signUp({userName, token}: SignUpParams) {
-    const optionsResponse = await this.api.registrationOptions({userName, token});
+  async signUp({userName, token, authenticatorAttachment = "platform"}: SignUpParams) {
+    const optionsResponse = await this.api.registrationOptions({userName, token, authenticatorAttachment});
 
     const registrationResponse = await startRegistration(optionsResponse.options);
 


### PR DESCRIPTION
Changing the default behaviour to use `platform` as it tends to be a better UX.

To keep the existing behaviour, you now need to pass `authenticatorAttachment: null` to the `signUp()` function.