### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
For some reason the last release failed to publish all the `.d.ts` files.

When creating the package locally, and inspecting it it has all the relevant files. I'm thinking it could be down to the `plugin-json` we've added, but wanna try republishing to see what happens.

0.5.4:
![image](https://github.com/user-attachments/assets/c3e345e2-5732-4ff5-8574-5ce3b9d96ee6)

0.5.4 packed locally:
![image](https://github.com/user-attachments/assets/7900f7e4-561c-4879-a0d4-41322221c5f4)
