### PR TITLE
Add support for initiating qr code challenges using websockets/rest endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/push-api-client.ts
+++ b/src/api/push-api-client.ts
@@ -25,11 +25,7 @@ export class PushApiClient {
     return responseJson;
   }
 
-  async verify({
-    challengeId,
-  }: {
-    challengeId: string;
-  }): Promise<PushVerifyResponse | ErrorResponse> {
+  async verify({challengeId}: {challengeId: string}): Promise<PushVerifyResponse | ErrorResponse> {
     const body = {challengeId};
 
     const response = await fetch(`${this.baseUrl}/client/verify/push`, {
@@ -42,4 +38,4 @@ export class PushApiClient {
 
     return responseJson;
   }
-} 
+}

--- a/src/api/qr-code-api-client.ts
+++ b/src/api/qr-code-api-client.ts
@@ -11,8 +11,14 @@ export class QrCodeApiClient {
     this.baseUrl = baseUrl;
   }
 
-  async challenge({action}: {action: string}): Promise<QrCodeChallengeResponse | ErrorResponse> {
-    const body = {action};
+  async challenge({
+    action,
+    custom,
+  }: {
+    action: string;
+    custom?: Record<string, unknown>;
+  }): Promise<QrCodeChallengeResponse | ErrorResponse> {
+    const body = {action, custom};
 
     const response = await fetch(`${this.baseUrl}/client/challenge/qr-code`, {
       method: "POST",

--- a/src/api/types/push.ts
+++ b/src/api/types/push.ts
@@ -6,4 +6,4 @@ export type PushVerifyResponse = {
   isVerified: boolean;
   isConsumed: boolean;
   accessToken?: string;
-}; 
+};

--- a/src/api/types/qr-code.ts
+++ b/src/api/types/qr-code.ts
@@ -1,6 +1,10 @@
 export type QrCodeChallengeResponse = {
   challengeId: string;
-  deviceCode: string;
+  expiresAt: string;
+  /**
+   * Only available in polling mode
+   */
+  deviceCode?: string;
 };
 
 export type QrCodeVerifyResponse = {

--- a/src/api/types/websocket.ts
+++ b/src/api/types/websocket.ts
@@ -1,0 +1,47 @@
+export type WebSocketMessageType = "CREATE_CHALLENGE" | "CHALLENGE_CREATED" | "STATE_CHANGE";
+
+export type ChallengeState = "unclaimed" | "claimed" | "approved" | "rejected";
+
+export interface CreateChallengeMessage {
+  type: "CREATE_CHALLENGE";
+  data: {
+    challengeType: "QR_CODE";
+    actionCode: string;
+    custom?: Record<string, unknown>;
+  };
+}
+
+export interface ChallengeCreatedMessage {
+  type: "CHALLENGE_CREATED";
+  data: {
+    challengeId: string;
+    challengeType: "QR_CODE";
+    expiresAt: string;
+    state: ChallengeState;
+  };
+}
+
+export interface StateChangeMessage {
+  type: "STATE_CHANGE";
+  data: {
+    challengeId: string;
+    state: ChallengeState;
+    accessToken?: string;
+  };
+}
+
+export type WebSocketMessage = CreateChallengeMessage | ChallengeCreatedMessage | StateChangeMessage;
+
+export interface WebSocketQrCodeOptions {
+  action: string;
+  custom?: Record<string, unknown>;
+  refreshInterval?: number;
+  onRefresh?: (challengeId: string, expiresAt: string) => void;
+  onStateChange?: (state: ChallengeState, accessToken?: string) => void;
+}
+
+export interface WebSocketQrCodeResponse {
+  challengeId: string;
+  expiresAt: string;
+  state: ChallengeState;
+}

--- a/src/api/websocket-client.ts
+++ b/src/api/websocket-client.ts
@@ -1,0 +1,200 @@
+import {
+  WebSocketMessage,
+  CreateChallengeMessage,
+  ChallengeCreatedMessage,
+  StateChangeMessage,
+  WebSocketQrCodeOptions,
+  WebSocketQrCodeResponse,
+} from "./types/websocket";
+
+const CHALLENGE_CREATED_HANDLER = "CHALLENGE_CREATED_HANDLER";
+
+export class WebSocketClient {
+  private ws: WebSocket | null = null;
+  private baseUrl: string;
+  private tenantId: string;
+  private messageHandlers: Map<string, (message: WebSocketMessage) => void> = new Map();
+  private options: WebSocketQrCodeOptions | null = null;
+  private refreshInterval: NodeJS.Timeout | null = null;
+
+  constructor({baseUrl, tenantId}: {baseUrl: string; tenantId: string}) {
+    const wsUrl = baseUrl
+      .replace("https://", "wss://")
+      .replace("http://", "ws://")
+      .replace("v1", "ws-v1-challenge")
+      .replace("api", "api-ws");
+
+    this.baseUrl = wsUrl;
+    this.tenantId = tenantId;
+  }
+
+  async connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      try {
+        this.ws = new WebSocket(this.baseUrl, ["authsignal-ws", `x.authsignal.tenant.${this.tenantId}`]);
+
+        this.ws.onopen = () => {
+          resolve();
+        };
+
+        this.ws.onerror = (error) => {
+          reject(new Error(`WebSocket connection error: ${error}`));
+        };
+
+        this.ws.onclose = () => {
+          if (this.refreshInterval) {
+            clearInterval(this.refreshInterval);
+            this.refreshInterval = null;
+          }
+
+          this.messageHandlers.clear();
+
+          this.ws = null;
+        };
+
+        this.ws.onmessage = (event) => {
+          try {
+            const message = JSON.parse(event.data) as WebSocketMessage;
+            this.handleMessage(message);
+          } catch (error) {
+            console.error("Failed to parse WebSocket message:", error);
+          }
+        };
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  private handleMessage(message: WebSocketMessage): void {
+    if (message.type === "CHALLENGE_CREATED") {
+      const handler = this.messageHandlers.get(CHALLENGE_CREATED_HANDLER);
+      if (handler) {
+        handler(message);
+      } else {
+        throw new Error("Challenge created handler not found");
+      }
+    } else if (message.type === "STATE_CHANGE") {
+      const handler = this.messageHandlers.get(message.data.challengeId);
+      if (handler) {
+        handler(message);
+      }
+    }
+  }
+
+  async createQrCodeChallenge(options: WebSocketQrCodeOptions): Promise<WebSocketQrCodeResponse> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      await this.connect();
+    }
+
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+    }
+
+    this.options = options;
+
+    return new Promise((resolve, reject) => {
+      const handler = (message: WebSocketMessage) => {
+        if (message.type === "CHALLENGE_CREATED") {
+          const created = message as ChallengeCreatedMessage;
+
+          this.messageHandlers.delete(CHALLENGE_CREATED_HANDLER);
+
+          this.monitorChallengeState(created.data.challengeId, options);
+          this.startRefreshCycle(created.data.challengeId, options);
+
+          resolve({
+            challengeId: created.data.challengeId,
+            expiresAt: created.data.expiresAt,
+            state: created.data.state,
+          });
+        }
+      };
+
+      this.messageHandlers.set(CHALLENGE_CREATED_HANDLER, handler);
+      this.sendChallengeRequest(options).catch(reject);
+    });
+  }
+
+  private monitorChallengeState(challengeId: string, options: WebSocketQrCodeOptions): void {
+    this.messageHandlers.set(challengeId, (message: WebSocketMessage) => {
+      if (message.type === "STATE_CHANGE") {
+        const stateMessage = message as StateChangeMessage;
+        options.onStateChange?.(stateMessage.data.state, stateMessage.data.accessToken);
+
+        if (stateMessage.data.state === "approved" || stateMessage.data.state === "rejected") {
+          this.messageHandlers.delete(challengeId);
+        }
+      }
+    });
+  }
+
+  private startRefreshCycle(currentChallengeId: string, options: WebSocketQrCodeOptions): void {
+    const interval = options.refreshInterval || 9 * 60 * 1000;
+    let challengeId = currentChallengeId;
+
+    this.refreshInterval = setInterval(async () => {
+      this.messageHandlers.delete(challengeId);
+
+      try {
+        const newChallenge = await this.createQrCodeChallenge(options);
+        challengeId = newChallenge.challengeId;
+
+        options.onRefresh?.(newChallenge.challengeId, newChallenge.expiresAt);
+      } catch (error) {
+        console.error("Failed to refresh QR code challenge:", error);
+        if (this.refreshInterval) {
+          clearInterval(this.refreshInterval);
+          this.refreshInterval = null;
+        }
+      }
+    }, interval);
+  }
+
+  private async sendChallengeRequest(options: WebSocketQrCodeOptions): Promise<void> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      await this.connect();
+    }
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket connection could not be established");
+    }
+
+    this.sendMessage({
+      type: "CREATE_CHALLENGE",
+      data: {
+        challengeType: "QR_CODE",
+        actionCode: options.action,
+        custom: options.custom,
+      },
+    });
+  }
+
+  private sendMessage(message: CreateChallengeMessage): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("WebSocket not connected");
+    }
+    this.ws.send(JSON.stringify(message));
+  }
+
+  async refreshQrCodeChallenge({custom}: {custom?: Record<string, any>}): Promise<WebSocketQrCodeResponse> {
+    if (!this.options) {
+      throw new Error("Call createQrCodeChallenge first");
+    }
+
+    const newChallenge = await this.createQrCodeChallenge({
+      ...this.options,
+      ...(custom !== undefined && {custom}),
+    });
+
+    this.options.onRefresh?.(newChallenge.challengeId, newChallenge.expiresAt);
+
+    return newChallenge;
+  }
+
+  disconnect(): void {
+    if (this.ws) {
+      this.ws.close();
+    }
+  }
+}

--- a/src/authsignal.ts
+++ b/src/authsignal.ts
@@ -49,6 +49,7 @@ export class Authsignal {
     baseUrl = DEFAULT_BASE_URL,
     tenantId,
     onTokenExpired,
+    mode = "websocket",
   }: AuthsignalOptions) {
     this.cookieDomain = cookieDomain || getCookieDomain();
     this.anonymousIdCookieName = cookieName;
@@ -79,7 +80,7 @@ export class Authsignal {
     this.emailML = new EmailMagicLink({tenantId, baseUrl, onTokenExpired});
     this.sms = new Sms({tenantId, baseUrl, onTokenExpired});
     this.securityKey = new SecurityKey({tenantId, baseUrl, onTokenExpired});
-    this.qrCode = new QrCode({tenantId, baseUrl});
+    this.qrCode = new QrCode({tenantId, baseUrl, mode});
     this.push = new Push({tenantId, baseUrl});
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export type {Authenticator, VerificationMethod, EnrollResponse, ChallengeRespons
 export type {EnrollTotpResponse} from "./api/types/totp";
 export type {QrCodeChallengeResponse, QrCodeVerifyResponse} from "./api/types/qr-code";
 export type {PushChallengeResponse, PushVerifyResponse} from "./api/types/push";
+export type {WebSocketQrCodeOptions, WebSocketQrCodeResponse, ChallengeState} from "./api/types/websocket";

--- a/src/push.ts
+++ b/src/push.ts
@@ -34,4 +34,4 @@ export class Push {
 
     return handleApiResponse(response);
   }
-} 
+}

--- a/src/qr-code.ts
+++ b/src/qr-code.ts
@@ -1,9 +1,9 @@
-import {QrCodeApiClient} from "./api/qr-code-api-client";
 import {QrCodeChallengeResponse} from "./api/types/qr-code";
-import {WebSocketClient} from "./api/websocket-client";
 import {ChallengeState} from "./api/types/websocket";
-import {handleApiResponse} from "./helpers";
 import {AuthsignalResponse} from "./types";
+import {QrHandler} from "./qr-code/base-qr-handler";
+import {RestQrHandler} from "./qr-code/rest-qr-handler";
+import {WebSocketQrHandler} from "./qr-code/websocket-qr-handler";
 
 type Mode = "websocket" | "rest";
 
@@ -13,7 +13,7 @@ type QrCodeOptions = {
   mode: Mode;
 };
 
-type ChallengeParams = {
+export type ChallengeParams = {
   action: string;
   custom?: Record<string, unknown>;
   /** The interval in milliseconds at which the QR code challenge will be polled. Default: 5 seconds (Only used in REST API mode)*/
@@ -26,206 +26,26 @@ type ChallengeParams = {
   onStateChange: (state: ChallengeState, accessToken?: string) => void;
 };
 
-const DEFAULT_REFRESH_INTERVAL = 9 * 60 * 1000;
-const DEFAULT_POLL_INTERVAL = 5 * 1000;
-
 export class QrCode {
-  private api: QrCodeApiClient;
-  private wsClient: WebSocketClient;
-  private mode: Mode;
-  private pollingInterval?: NodeJS.Timeout;
-  private refreshTimeout?: NodeJS.Timeout;
-  private currentChallengeParams?: ChallengeParams;
+  private handler: QrHandler;
 
   constructor({baseUrl, tenantId, mode = "websocket"}: QrCodeOptions) {
-    this.api = new QrCodeApiClient({baseUrl, tenantId});
-    this.wsClient = new WebSocketClient({baseUrl, tenantId});
-    this.mode = mode;
+    if (mode === "websocket") {
+      this.handler = new WebSocketQrHandler({baseUrl, tenantId});
+    } else {
+      this.handler = new RestQrHandler({baseUrl, tenantId});
+    }
   }
 
   async challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
-    if (this.mode === "websocket") {
-      const response = await this.wsClient.createQrCodeChallenge({
-        action: params.action,
-        custom: params.custom,
-        refreshInterval: params.refreshInterval,
-        onRefresh: params.onRefresh,
-        onStateChange: params.onStateChange,
-      });
-
-      return {
-        data: {
-          challengeId: response.challengeId,
-          expiresAt: response.expiresAt,
-        } as QrCodeChallengeResponse,
-      };
-    } else {
-      const response = await this.api.challenge({action: params.action, custom: params.custom});
-      const result = handleApiResponse(response);
-
-      if (result.data) {
-        this.currentChallengeParams = params;
-
-        this.clearPolling();
-
-        const pollInterval = params.pollInterval || DEFAULT_POLL_INTERVAL;
-        const refreshInterval = params.refreshInterval || DEFAULT_REFRESH_INTERVAL;
-
-        if (result.data.deviceCode) {
-          this.startPolling({
-            challengeId: result.data.challengeId,
-            deviceCode: result.data.deviceCode,
-            onStateChange: params.onStateChange,
-            pollInterval,
-          });
-        }
-
-        if (params.onRefresh) {
-          this.startRefreshTimer({
-            refreshInterval,
-            onRefresh: params.onRefresh,
-            action: params.action,
-            custom: params.custom,
-            onStateChange: params.onStateChange,
-            pollInterval,
-          });
-        }
-      }
-
-      return result;
-    }
+    return this.handler.challenge(params);
   }
 
   async refresh({custom}: {custom?: Record<string, unknown>} = {}): Promise<void> {
-    if (this.mode === "websocket") {
-      await this.wsClient.refreshQrCodeChallenge({custom});
-    } else {
-      if (this.currentChallengeParams) {
-        const response = await this.api.challenge({
-          action: this.currentChallengeParams.action,
-          custom: custom || this.currentChallengeParams.custom,
-        });
-        const result = handleApiResponse(response);
-
-        if (result.data) {
-          this.clearPolling();
-
-          if (this.currentChallengeParams.onRefresh) {
-            this.currentChallengeParams.onRefresh(result.data.challengeId, result.data.expiresAt);
-          }
-
-          if (result.data.deviceCode) {
-            this.startPolling({
-              challengeId: result.data.challengeId,
-              deviceCode: result.data.deviceCode,
-              onStateChange: this.currentChallengeParams.onStateChange,
-              pollInterval: DEFAULT_POLL_INTERVAL,
-            });
-          }
-
-          if (this.currentChallengeParams.onRefresh) {
-            this.startRefreshTimer({
-              refreshInterval: this.currentChallengeParams.refreshInterval || DEFAULT_REFRESH_INTERVAL,
-              onRefresh: this.currentChallengeParams.onRefresh,
-              action: this.currentChallengeParams.action,
-              custom: this.currentChallengeParams.custom,
-              onStateChange: this.currentChallengeParams.onStateChange,
-              pollInterval: DEFAULT_POLL_INTERVAL,
-            });
-          }
-        }
-      }
-    }
-  }
-
-  private startPolling({
-    challengeId,
-    deviceCode,
-    onStateChange,
-    pollInterval,
-  }: {
-    challengeId: string;
-    deviceCode: string;
-    onStateChange: (state: ChallengeState, accessToken?: string) => void;
-    pollInterval: number;
-  }): void {
-    this.pollingInterval = setInterval(async () => {
-      const response = await this.api.verify({challengeId, deviceCode});
-      const result = handleApiResponse(response);
-
-      if (result.data) {
-        if (result.data.isVerified) {
-          onStateChange("approved", result.data.token);
-          this.clearPolling();
-        } else if (result.data.isClaimed) {
-          onStateChange("claimed");
-        }
-      }
-    }, pollInterval);
-  }
-
-  private startRefreshTimer({
-    refreshInterval,
-    onRefresh,
-    action,
-    custom,
-    onStateChange,
-    pollInterval,
-  }: {
-    refreshInterval: number;
-    onRefresh: (challengeId: string, expiresAt: string) => void;
-    action: string;
-    custom?: Record<string, unknown>;
-    onStateChange: (state: ChallengeState, accessToken?: string) => void;
-    pollInterval?: number;
-  }): void {
-    this.refreshTimeout = setTimeout(async () => {
-      const response = await this.api.challenge({action, custom});
-      const result = handleApiResponse(response);
-
-      if (result.data) {
-        this.clearPolling();
-
-        onRefresh(result.data.challengeId, result.data.expiresAt);
-
-        if (result.data.deviceCode && pollInterval) {
-          this.startPolling({
-            challengeId: result.data.challengeId,
-            deviceCode: result.data.deviceCode,
-            onStateChange,
-            pollInterval,
-          });
-        }
-
-        this.startRefreshTimer({
-          refreshInterval,
-          onRefresh,
-          action,
-          custom,
-          onStateChange,
-          pollInterval,
-        });
-      }
-    }, refreshInterval);
-  }
-
-  private clearPolling(): void {
-    if (this.pollingInterval) {
-      clearInterval(this.pollingInterval);
-      this.pollingInterval = undefined;
-    }
-    if (this.refreshTimeout) {
-      clearTimeout(this.refreshTimeout);
-      this.refreshTimeout = undefined;
-    }
+    return this.handler.refresh({custom});
   }
 
   disconnect(): void {
-    if (this.mode === "websocket") {
-      this.wsClient.disconnect();
-    } else {
-      this.clearPolling();
-      this.currentChallengeParams = undefined;
-    }
+    this.handler.disconnect();
   }
 }

--- a/src/qr-code.ts
+++ b/src/qr-code.ts
@@ -1,15 +1,27 @@
 import {QrCodeApiClient} from "./api/qr-code-api-client";
 import {QrCodeChallengeResponse, QrCodeVerifyResponse} from "./api/types/qr-code";
+import {WebSocketClient} from "./api/websocket-client";
+import {ChallengeState, WebSocketQrCodeOptions} from "./api/types/websocket";
 import {handleApiResponse} from "./helpers";
 import {AuthsignalResponse} from "./types";
+
+type QrCodeMode = "websocket" | "polling";
 
 type QrCodeOptions = {
   baseUrl: string;
   tenantId: string;
+  mode?: QrCodeMode;
 };
 
 type ChallengeParams = {
   action: string;
+  custom?: Record<string, unknown>;
+  /** The interval in milliseconds at which the QR code challenge will be refreshed. Default: 9 minutes */
+  refreshInterval?: number;
+  /** A callback function that is called when the QR code challenge is refreshed. */
+  onRefresh?: (challengeId: string, expiresAt: string) => void;
+  /** A callback function that is called when the state of the QR code challenge changes. */
+  onStateChange?: (state: ChallengeState, accessToken?: string) => void;
 };
 
 type VerifyParams = {
@@ -19,20 +31,58 @@ type VerifyParams = {
 
 export class QrCode {
   private api: QrCodeApiClient;
+  private wsClient: WebSocketClient;
+  private mode: QrCodeMode;
 
-  constructor({baseUrl, tenantId}: QrCodeOptions) {
+  constructor({baseUrl, tenantId, mode = "websocket"}: QrCodeOptions) {
     this.api = new QrCodeApiClient({baseUrl, tenantId});
+    this.wsClient = new WebSocketClient({baseUrl, tenantId});
+    this.mode = mode;
   }
 
-  async challenge({action}: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
-    const response = await this.api.challenge({action});
+  async challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
+    if (this.mode === "websocket") {
+      try {
+        if (!params.onStateChange) {
+          throw new Error("onStateChange is required");
+        }
 
-    return handleApiResponse(response);
+        const response = await this.wsClient.createQrCodeChallenge({
+          action: params.action,
+          custom: params.custom,
+          refreshInterval: params.refreshInterval,
+          onRefresh: params.onRefresh,
+          onStateChange: params.onStateChange,
+        });
+
+        return {
+          data: {
+            challengeId: response.challengeId,
+            expiresAt: response.expiresAt,
+          } as QrCodeChallengeResponse,
+        };
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    } else {
+      const response = await this.api.challenge({action: params.action, custom: params.custom});
+      return handleApiResponse(response);
+    }
   }
 
   async verify({challengeId, deviceCode}: VerifyParams): Promise<AuthsignalResponse<QrCodeVerifyResponse>> {
     const response = await this.api.verify({challengeId, deviceCode});
 
     return handleApiResponse(response);
+  }
+
+  async refresh({custom}: {custom?: Record<string, any>} = {}): Promise<void> {
+    await this.wsClient.refreshQrCodeChallenge({custom});
+  }
+
+  disconnect(): void {
+    this.wsClient.disconnect();
   }
 }

--- a/src/qr-code.ts
+++ b/src/qr-code.ts
@@ -1,38 +1,41 @@
 import {QrCodeApiClient} from "./api/qr-code-api-client";
-import {QrCodeChallengeResponse, QrCodeVerifyResponse} from "./api/types/qr-code";
+import {QrCodeChallengeResponse} from "./api/types/qr-code";
 import {WebSocketClient} from "./api/websocket-client";
-import {ChallengeState, WebSocketQrCodeOptions} from "./api/types/websocket";
+import {ChallengeState} from "./api/types/websocket";
 import {handleApiResponse} from "./helpers";
 import {AuthsignalResponse} from "./types";
 
-type QrCodeMode = "websocket" | "polling";
+type Mode = "websocket" | "rest";
 
 type QrCodeOptions = {
   baseUrl: string;
   tenantId: string;
-  mode?: QrCodeMode;
+  mode: Mode;
 };
 
 type ChallengeParams = {
   action: string;
   custom?: Record<string, unknown>;
+  /** The interval in milliseconds at which the QR code challenge will be polled. Default: 5 seconds (Only used in REST API mode)*/
+  pollInterval?: number;
   /** The interval in milliseconds at which the QR code challenge will be refreshed. Default: 9 minutes */
   refreshInterval?: number;
   /** A callback function that is called when the QR code challenge is refreshed. */
   onRefresh?: (challengeId: string, expiresAt: string) => void;
   /** A callback function that is called when the state of the QR code challenge changes. */
-  onStateChange?: (state: ChallengeState, accessToken?: string) => void;
+  onStateChange: (state: ChallengeState, accessToken?: string) => void;
 };
 
-type VerifyParams = {
-  challengeId: string;
-  deviceCode: string;
-};
+const DEFAULT_REFRESH_INTERVAL = 9 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL = 5 * 1000;
 
 export class QrCode {
   private api: QrCodeApiClient;
   private wsClient: WebSocketClient;
-  private mode: QrCodeMode;
+  private mode: Mode;
+  private pollingInterval?: NodeJS.Timeout;
+  private refreshTimeout?: NodeJS.Timeout;
+  private currentChallengeParams?: ChallengeParams;
 
   constructor({baseUrl, tenantId, mode = "websocket"}: QrCodeOptions) {
     this.api = new QrCodeApiClient({baseUrl, tenantId});
@@ -42,47 +45,187 @@ export class QrCode {
 
   async challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
     if (this.mode === "websocket") {
-      try {
-        if (!params.onStateChange) {
-          throw new Error("onStateChange is required");
-        }
+      const response = await this.wsClient.createQrCodeChallenge({
+        action: params.action,
+        custom: params.custom,
+        refreshInterval: params.refreshInterval,
+        onRefresh: params.onRefresh,
+        onStateChange: params.onStateChange,
+      });
 
-        const response = await this.wsClient.createQrCodeChallenge({
-          action: params.action,
-          custom: params.custom,
-          refreshInterval: params.refreshInterval,
-          onRefresh: params.onRefresh,
-          onStateChange: params.onStateChange,
-        });
-
-        return {
-          data: {
-            challengeId: response.challengeId,
-            expiresAt: response.expiresAt,
-          } as QrCodeChallengeResponse,
-        };
-      } catch (error) {
-        return {
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
+      return {
+        data: {
+          challengeId: response.challengeId,
+          expiresAt: response.expiresAt,
+        } as QrCodeChallengeResponse,
+      };
     } else {
       const response = await this.api.challenge({action: params.action, custom: params.custom});
-      return handleApiResponse(response);
+      const result = handleApiResponse(response);
+
+      if (result.data) {
+        this.currentChallengeParams = params;
+
+        this.clearPolling();
+
+        const pollInterval = params.pollInterval || DEFAULT_POLL_INTERVAL;
+        const refreshInterval = params.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+
+        if (result.data.deviceCode) {
+          this.startPolling({
+            challengeId: result.data.challengeId,
+            deviceCode: result.data.deviceCode,
+            onStateChange: params.onStateChange,
+            pollInterval,
+          });
+        }
+
+        if (params.onRefresh) {
+          this.startRefreshTimer({
+            refreshInterval,
+            onRefresh: params.onRefresh,
+            action: params.action,
+            custom: params.custom,
+            onStateChange: params.onStateChange,
+            pollInterval,
+          });
+        }
+      }
+
+      return result;
     }
   }
 
-  async verify({challengeId, deviceCode}: VerifyParams): Promise<AuthsignalResponse<QrCodeVerifyResponse>> {
-    const response = await this.api.verify({challengeId, deviceCode});
+  async refresh({custom}: {custom?: Record<string, unknown>} = {}): Promise<void> {
+    if (this.mode === "websocket") {
+      await this.wsClient.refreshQrCodeChallenge({custom});
+    } else {
+      if (this.currentChallengeParams) {
+        const response = await this.api.challenge({
+          action: this.currentChallengeParams.action,
+          custom: custom || this.currentChallengeParams.custom,
+        });
+        const result = handleApiResponse(response);
 
-    return handleApiResponse(response);
+        if (result.data) {
+          this.clearPolling();
+
+          if (this.currentChallengeParams.onRefresh) {
+            this.currentChallengeParams.onRefresh(result.data.challengeId, result.data.expiresAt);
+          }
+
+          if (result.data.deviceCode) {
+            this.startPolling({
+              challengeId: result.data.challengeId,
+              deviceCode: result.data.deviceCode,
+              onStateChange: this.currentChallengeParams.onStateChange,
+              pollInterval: DEFAULT_POLL_INTERVAL,
+            });
+          }
+
+          if (this.currentChallengeParams.onRefresh) {
+            this.startRefreshTimer({
+              refreshInterval: this.currentChallengeParams.refreshInterval || DEFAULT_REFRESH_INTERVAL,
+              onRefresh: this.currentChallengeParams.onRefresh,
+              action: this.currentChallengeParams.action,
+              custom: this.currentChallengeParams.custom,
+              onStateChange: this.currentChallengeParams.onStateChange,
+              pollInterval: DEFAULT_POLL_INTERVAL,
+            });
+          }
+        }
+      }
+    }
   }
 
-  async refresh({custom}: {custom?: Record<string, any>} = {}): Promise<void> {
-    await this.wsClient.refreshQrCodeChallenge({custom});
+  private startPolling({
+    challengeId,
+    deviceCode,
+    onStateChange,
+    pollInterval,
+  }: {
+    challengeId: string;
+    deviceCode: string;
+    onStateChange: (state: ChallengeState, accessToken?: string) => void;
+    pollInterval: number;
+  }): void {
+    this.pollingInterval = setInterval(async () => {
+      const response = await this.api.verify({challengeId, deviceCode});
+      const result = handleApiResponse(response);
+
+      if (result.data) {
+        if (result.data.isVerified) {
+          onStateChange("approved", result.data.token);
+          this.clearPolling();
+        } else if (result.data.isClaimed) {
+          onStateChange("claimed");
+        }
+      }
+    }, pollInterval);
+  }
+
+  private startRefreshTimer({
+    refreshInterval,
+    onRefresh,
+    action,
+    custom,
+    onStateChange,
+    pollInterval,
+  }: {
+    refreshInterval: number;
+    onRefresh: (challengeId: string, expiresAt: string) => void;
+    action: string;
+    custom?: Record<string, unknown>;
+    onStateChange: (state: ChallengeState, accessToken?: string) => void;
+    pollInterval?: number;
+  }): void {
+    this.refreshTimeout = setTimeout(async () => {
+      const response = await this.api.challenge({action, custom});
+      const result = handleApiResponse(response);
+
+      if (result.data) {
+        this.clearPolling();
+
+        onRefresh(result.data.challengeId, result.data.expiresAt);
+
+        if (result.data.deviceCode && pollInterval) {
+          this.startPolling({
+            challengeId: result.data.challengeId,
+            deviceCode: result.data.deviceCode,
+            onStateChange,
+            pollInterval,
+          });
+        }
+
+        this.startRefreshTimer({
+          refreshInterval,
+          onRefresh,
+          action,
+          custom,
+          onStateChange,
+          pollInterval,
+        });
+      }
+    }, refreshInterval);
+  }
+
+  private clearPolling(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = undefined;
+    }
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = undefined;
+    }
   }
 
   disconnect(): void {
-    this.wsClient.disconnect();
+    if (this.mode === "websocket") {
+      this.wsClient.disconnect();
+    } else {
+      this.clearPolling();
+      this.currentChallengeParams = undefined;
+    }
   }
 }

--- a/src/qr-code/base-qr-handler.ts
+++ b/src/qr-code/base-qr-handler.ts
@@ -1,0 +1,15 @@
+import {ChallengeParams} from "../qr-code";
+import {AuthsignalResponse} from "../types";
+import {QrCodeChallengeResponse} from "../api/types/qr-code";
+
+export interface QrHandler {
+  challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>>;
+  refresh(params: {custom?: Record<string, unknown>}): Promise<void>;
+  disconnect(): void;
+}
+
+export abstract class BaseQrHandler implements QrHandler {
+  abstract challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>>;
+  abstract refresh(params: {custom?: Record<string, unknown>}): Promise<void>;
+  abstract disconnect(): void;
+}

--- a/src/qr-code/rest-qr-handler.ts
+++ b/src/qr-code/rest-qr-handler.ts
@@ -1,0 +1,169 @@
+import {QrCodeApiClient} from "../api/qr-code-api-client";
+import {QrCodeChallengeResponse} from "../api/types/qr-code";
+import {ChallengeState} from "../api/types/websocket";
+import {handleApiResponse} from "../helpers";
+import {AuthsignalResponse} from "../types";
+import {ChallengeParams} from "../qr-code";
+import {BaseQrHandler} from "./base-qr-handler";
+
+const DEFAULT_REFRESH_INTERVAL = 9 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL = 5 * 1000;
+
+export class RestQrHandler extends BaseQrHandler {
+  private api: QrCodeApiClient;
+  private pollingInterval?: NodeJS.Timeout;
+  private refreshTimeout?: NodeJS.Timeout;
+  private currentChallengeParams?: ChallengeParams;
+
+  constructor({baseUrl, tenantId}: {baseUrl: string; tenantId: string}) {
+    super();
+    this.api = new QrCodeApiClient({baseUrl, tenantId});
+  }
+
+  async challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
+    const response = await this.api.challenge({action: params.action, custom: params.custom});
+    const result = handleApiResponse(response);
+
+    if (result.data) {
+      this.currentChallengeParams = params;
+      this.clearPolling();
+
+      const pollInterval = params.pollInterval || DEFAULT_POLL_INTERVAL;
+      const refreshInterval = params.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+
+      if (result.data.deviceCode) {
+        this.startPolling({
+          challengeId: result.data.challengeId,
+          deviceCode: result.data.deviceCode,
+          onStateChange: params.onStateChange,
+          pollInterval,
+        });
+      }
+
+      if (params.onRefresh) {
+        const onRefresh = params.onRefresh;
+        this.startRefreshTimer(
+          () => this.performRefresh(params.action, params.custom, onRefresh, params.onStateChange, pollInterval),
+          refreshInterval
+        );
+      }
+    }
+
+    return result;
+  }
+
+  async refresh({custom}: {custom?: Record<string, unknown>} = {}): Promise<void> {
+    if (!this.currentChallengeParams) return;
+
+    const response = await this.api.challenge({
+      action: this.currentChallengeParams.action,
+      custom: custom || this.currentChallengeParams.custom,
+    });
+    const result = handleApiResponse(response);
+
+    if (result.data) {
+      this.clearPolling();
+
+      if (this.currentChallengeParams.onRefresh) {
+        this.currentChallengeParams.onRefresh(result.data.challengeId, result.data.expiresAt);
+      }
+
+      if (result.data.deviceCode) {
+        this.startPolling({
+          challengeId: result.data.challengeId,
+          deviceCode: result.data.deviceCode,
+          onStateChange: this.currentChallengeParams.onStateChange,
+          pollInterval: this.currentChallengeParams.pollInterval || DEFAULT_POLL_INTERVAL,
+        });
+      }
+
+      if (this.currentChallengeParams.onRefresh) {
+        const refreshInterval = this.currentChallengeParams.refreshInterval || DEFAULT_REFRESH_INTERVAL;
+        const {action, custom, onRefresh, onStateChange, pollInterval} = this.currentChallengeParams;
+        this.startRefreshTimer(
+          () => this.performRefresh(action, custom, onRefresh, onStateChange, pollInterval || DEFAULT_POLL_INTERVAL),
+          refreshInterval
+        );
+      }
+    }
+  }
+
+  disconnect(): void {
+    this.clearPolling();
+    this.clearRefreshTimer();
+    this.currentChallengeParams = undefined;
+  }
+
+  private startRefreshTimer(callback: () => Promise<void>, interval: number): void {
+    this.clearRefreshTimer();
+    this.refreshTimeout = setTimeout(async () => {
+      await callback();
+      this.startRefreshTimer(callback, interval);
+    }, interval);
+  }
+
+  private clearRefreshTimer(): void {
+    if (this.refreshTimeout) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = undefined;
+    }
+  }
+
+  private async performRefresh(
+    action: string,
+    custom: Record<string, unknown> | undefined,
+    onRefresh: (challengeId: string, expiresAt: string) => void,
+    onStateChange: (state: ChallengeState, accessToken?: string) => void,
+    pollInterval: number
+  ): Promise<void> {
+    const response = await this.api.challenge({action, custom});
+    const result = handleApiResponse(response);
+
+    if (result.data) {
+      this.clearPolling();
+      onRefresh(result.data.challengeId, result.data.expiresAt);
+
+      if (result.data.deviceCode) {
+        this.startPolling({
+          challengeId: result.data.challengeId,
+          deviceCode: result.data.deviceCode,
+          onStateChange,
+          pollInterval,
+        });
+      }
+    }
+  }
+
+  private startPolling({
+    challengeId,
+    deviceCode,
+    onStateChange,
+    pollInterval,
+  }: {
+    challengeId: string;
+    deviceCode: string;
+    onStateChange: (state: ChallengeState, accessToken?: string) => void;
+    pollInterval: number;
+  }): void {
+    this.pollingInterval = setInterval(async () => {
+      const response = await this.api.verify({challengeId, deviceCode});
+      const result = handleApiResponse(response);
+
+      if (result.data) {
+        if (result.data.isVerified) {
+          onStateChange("approved", result.data.token);
+          this.clearPolling();
+        } else if (result.data.isClaimed) {
+          onStateChange("claimed");
+        }
+      }
+    }, pollInterval);
+  }
+
+  private clearPolling(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = undefined;
+    }
+  }
+}

--- a/src/qr-code/websocket-qr-handler.ts
+++ b/src/qr-code/websocket-qr-handler.ts
@@ -1,0 +1,39 @@
+import {WebSocketClient} from "../api/websocket-client";
+import {QrCodeChallengeResponse} from "../api/types/qr-code";
+import {AuthsignalResponse} from "../types";
+import {ChallengeParams} from "../qr-code";
+import {BaseQrHandler} from "./base-qr-handler";
+
+export class WebSocketQrHandler extends BaseQrHandler {
+  private wsClient: WebSocketClient;
+
+  constructor({baseUrl, tenantId}: {baseUrl: string; tenantId: string}) {
+    super();
+    this.wsClient = new WebSocketClient({baseUrl, tenantId});
+  }
+
+  async challenge(params: ChallengeParams): Promise<AuthsignalResponse<QrCodeChallengeResponse>> {
+    const response = await this.wsClient.createQrCodeChallenge({
+      action: params.action,
+      custom: params.custom,
+      refreshInterval: params.refreshInterval,
+      onRefresh: params.onRefresh,
+      onStateChange: params.onStateChange,
+    });
+
+    return {
+      data: {
+        challengeId: response.challengeId,
+        expiresAt: response.expiresAt,
+      } as QrCodeChallengeResponse,
+    };
+  }
+
+  async refresh({custom}: {custom?: Record<string, unknown>} = {}): Promise<void> {
+    await this.wsClient.refreshQrCodeChallenge({custom});
+  }
+
+  disconnect(): void {
+    this.wsClient.disconnect();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export type AuthsignalOptions = {
   baseUrl?: string;
   tenantId: string;
   onTokenExpired?: () => void;
+  mode: "rest" | "websocket";
 };
 
 export enum AuthsignalWindowMessage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export type AuthsignalOptions = {
   baseUrl?: string;
   tenantId: string;
   onTokenExpired?: () => void;
-  mode: "rest" | "websocket";
+  mode?: "rest" | "websocket";
 };
 
 export enum AuthsignalWindowMessage {


### PR DESCRIPTION
### New Features

Initialize Authsignal client in `websocket` or `rest` mode. For supported features, `websocket` mode will initialize a websocket connection, or `rest` mode will use a polling mechanism. Defaults to `websocket`

```js
new Authsignal({
    tenantId: process.env.NEXT_PUBLIC_AUTHSIGNAL_TENANT_ID!,
    baseUrl: process.env.NEXT_PUBLIC_AUTHSIGNAL_BASE_URL!,
    // mode: "rest", // defaults to "websocket"
  });
```

Starting a websocket challenge and providing a callback for handling the state changes

```js
const {data} = await authsignal.qrCode.challenge({
        action: "kiosk-login",
        custom: {},
        refreshInterval: 60_000,
        pollingInterval: 1_000, // Only relevant for `rest` mode
        onRefresh: (challengeId, expiresAt) => {},
        onStateChange: (state: ChallengeState, token?: string) => {
          if (state === "approved" && token) {
            validateToken(token);
          }
        },
      });
```

To manually refresh a challenge

```js
await authsignal.qrCode.refresh();
```

### Checklist
- [x] Version bumped
- [ ] Documentation updated 