### PR TITLE
add passkey sync using signal api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 coverage/
 *.tsbuildinfo
 .vscode
+example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/browser",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/passkey-api-client.ts
+++ b/src/api/passkey-api-client.ts
@@ -13,7 +13,7 @@ import {
   VerifyRequest,
   VerifyResponse,
 } from "./types/passkey";
-import {ApiClientOptions} from "./types/shared";
+import {ApiClientOptions, Authenticator} from "./types/shared";
 
 export class PasskeyApiClient {
   tenantId: string;
@@ -132,6 +132,26 @@ export class PasskeyApiClient {
       method: "POST",
       headers: buildHeaders({token, tenantId: this.tenantId}),
       body: JSON.stringify(body),
+      credentials: useCookies ? "include" : "same-origin",
+    });
+
+    const responseJson = await response.json();
+
+    handleTokenExpired({response: responseJson, onTokenExpired: this.onTokenExpired});
+
+    return responseJson;
+  }
+
+  async getAuthenticators({
+    token,
+    useCookies,
+  }: {
+    token?: string;
+    useCookies?: boolean;
+  }): Promise<Authenticator[] | ErrorResponse> {
+    const response = await fetch(`${this.baseUrl}/client/user-authenticators`, {
+      method: "GET",
+      headers: buildHeaders({token, tenantId: this.tenantId}),
       credentials: useCookies ? "include" : "same-origin",
     });
 

--- a/src/api/types/passkey.ts
+++ b/src/api/types/passkey.ts
@@ -5,6 +5,7 @@ import {
   RegistrationResponseJSON,
 } from "@simplewebauthn/browser";
 import {Authenticator} from "./shared";
+import {ErrorCode} from "../../types";
 
 export type RegistrationOptsRequest = {
   username?: string;
@@ -74,5 +75,6 @@ export type ChallengeResponse = {
 
 export type ErrorResponse = {
   error: string;
+  errorCode?: ErrorCode;
   errorDescription?: string;
 };

--- a/src/passkey-signal.ts
+++ b/src/passkey-signal.ts
@@ -1,0 +1,79 @@
+type SignalAllAcceptedCredentialsParams = {
+  rpId: string;
+  userId: string;
+  credentialIds: string[];
+};
+
+type SignalUnknownCredentialParams = {
+  rpId: string;
+  credentialId: string;
+};
+
+type SignalCapablePublicKeyCredential = {
+  signalAllAcceptedCredentials?: (params: {
+    rpId: string;
+    userId: string;
+    allAcceptedCredentialIds: string[];
+  }) => Promise<void>;
+  signalUnknownCredential?: (params: {rpId: string; credentialId: string}) => Promise<void>;
+};
+
+function getSignalApi(): SignalCapablePublicKeyCredential | null {
+  if (typeof window === "undefined" || typeof window.PublicKeyCredential === "undefined") {
+    return null;
+  }
+
+  return window.PublicKeyCredential as unknown as SignalCapablePublicKeyCredential;
+}
+
+export function isSignalAllAcceptedSupported(): boolean {
+  const api = getSignalApi();
+  return Boolean(api && typeof api.signalAllAcceptedCredentials === "function");
+}
+
+export function isSignalUnknownCredentialSupported(): boolean {
+  const api = getSignalApi();
+  return Boolean(api && typeof api.signalUnknownCredential === "function");
+}
+
+export async function signalAllAcceptedCredentials(
+  {rpId, userId, credentialIds}: SignalAllAcceptedCredentialsParams,
+  enableLogging: boolean
+): Promise<void> {
+  const api = getSignalApi();
+
+  if (!api?.signalAllAcceptedCredentials) {
+    return;
+  }
+
+  try {
+    await api.signalAllAcceptedCredentials({
+      rpId,
+      userId,
+      allAcceptedCredentialIds: credentialIds,
+    });
+  } catch (e) {
+    if (enableLogging) {
+      console.warn("[Authsignal] signalAllAcceptedCredentials failed", e);
+    }
+  }
+}
+
+export async function signalUnknownCredential(
+  {rpId, credentialId}: SignalUnknownCredentialParams,
+  enableLogging: boolean
+): Promise<void> {
+  const api = getSignalApi();
+
+  if (!api?.signalUnknownCredential) {
+    return;
+  }
+
+  try {
+    await api.signalUnknownCredential({rpId, credentialId});
+  } catch (e) {
+    if (enableLogging) {
+      console.warn("[Authsignal] signalUnknownCredential failed", e);
+    }
+  }
+}

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -10,8 +10,9 @@ import {
 import {PasskeyApiClient} from "./api/passkey-api-client";
 import {TokenCache} from "./token-cache";
 import {handleErrorResponse, handleWebAuthnError} from "./helpers";
-import {AuthsignalResponse} from "./types";
-import {Authenticator} from "./api/types/shared";
+import {signalAllAcceptedCredentials, signalUnknownCredential} from "./passkey-signal";
+import {AuthsignalResponse, ErrorCode} from "./types";
+import {Authenticator, VerificationMethod} from "./api/types/shared";
 
 type PasskeyOptions = {
   baseUrl: string;
@@ -29,6 +30,7 @@ type SignUpParams = {
   hints?: PublicKeyCredentialHint[];
   useAutoRegister?: boolean;
   useCookies?: boolean;
+  syncCredentials?: boolean;
 };
 
 type SignUpResponse = {
@@ -43,6 +45,7 @@ type SignInParams = {
   token?: string;
   useCookies?: boolean;
   onVerificationStarted?: () => unknown;
+  syncCredentials?: boolean;
 };
 
 type SignInResponse = {
@@ -53,6 +56,10 @@ type SignInResponse = {
   username?: string;
   displayName?: string;
   authenticationResponse?: AuthenticationResponseJSON;
+};
+
+type PublicKeyCredentialConstructorWithCapabilities = typeof PublicKeyCredential & {
+  getClientCapabilities?: () => Promise<{conditionalCreate?: boolean}>;
 };
 
 let autofillRequestPending = false;
@@ -78,6 +85,7 @@ export class Passkey {
     hints,
     useAutoRegister = false,
     useCookies = false,
+    syncCredentials = true,
   }: SignUpParams): Promise<AuthsignalResponse<SignUpResponse>> {
     const userToken = token ?? this.cache.token;
 
@@ -133,6 +141,22 @@ export class Passkey {
         this.cache.token = addAuthenticatorResponse.accessToken;
       }
 
+      if (
+        syncCredentials &&
+        addAuthenticatorResponse.isVerified &&
+        (addAuthenticatorResponse.accessToken || useCookies)
+      ) {
+        const rpId = optionsResponse.options.rp.id ?? window.location.hostname;
+
+        void this.syncPasskeysWithCredentialManager({
+          rpId,
+          userHandle: optionsResponse.options.user.id,
+          credentialId: registrationResponse.id,
+          token: addAuthenticatorResponse.accessToken,
+          useCookies,
+        });
+      }
+
       return {
         data: {
           token: addAuthenticatorResponse.accessToken,
@@ -157,6 +181,8 @@ export class Passkey {
     if (params?.action && params.token) {
       throw new Error("action is not supported when providing a token");
     }
+
+    const syncCredentials = params?.syncCredentials ?? true;
 
     if (params?.autofill) {
       if (autofillRequestPending) {
@@ -212,6 +238,14 @@ export class Passkey {
       if ("error" in verifyResponse) {
         autofillRequestPending = false;
 
+        if (syncCredentials && verifyResponse.errorCode === ErrorCode.unknown_credential) {
+          const rpId = this.getAuthOptionsRpId(optionsResponse.options);
+
+          await signalUnknownCredential({rpId, credentialId: authenticationResponse.id}, this.enableLogging);
+
+          this.removeCredentialFromLocalCache(authenticationResponse.id);
+        }
+
         return handleErrorResponse({errorResponse: verifyResponse, enableLogging: this.enableLogging});
       }
 
@@ -221,6 +255,25 @@ export class Passkey {
 
       if (verifyResponse.accessToken) {
         this.cache.token = verifyResponse.accessToken;
+      }
+
+      const userHandle = authenticationResponse.response.userHandle;
+
+      if (
+        syncCredentials &&
+        verifyResponse.isVerified &&
+        (verifyResponse.accessToken || params?.useCookies) &&
+        userHandle
+      ) {
+        const rpId = this.getAuthOptionsRpId(optionsResponse.options);
+
+        void this.syncPasskeysWithCredentialManager({
+          rpId,
+          userHandle,
+          credentialId: authenticationResponse.id,
+          token: verifyResponse.accessToken,
+          useCookies: params?.useCookies,
+        });
       }
 
       const {accessToken: token, userId, userAuthenticatorId, username, userDisplayName, isVerified} = verifyResponse;
@@ -299,13 +352,88 @@ export class Passkey {
   }
 
   private async doesBrowserSupportConditionalCreate() {
-    if (window.PublicKeyCredential && PublicKeyCredential.getClientCapabilities) {
-      const capabilities = await PublicKeyCredential.getClientCapabilities();
+    const publicKeyCredential = window.PublicKeyCredential as
+      | PublicKeyCredentialConstructorWithCapabilities
+      | undefined;
+
+    if (publicKeyCredential?.getClientCapabilities) {
+      const capabilities = await publicKeyCredential.getClientCapabilities();
       if (capabilities.conditionalCreate) {
         return true;
       }
     }
 
     return false;
+  }
+
+  private getAuthOptionsRpId(options: unknown): string {
+    const rpId = (options as {rpId?: string})?.rpId;
+    return rpId ?? window.location.hostname;
+  }
+
+  private async syncPasskeysWithCredentialManager({
+    rpId,
+    userHandle,
+    credentialId,
+    token,
+    useCookies,
+  }: {
+    rpId: string;
+    userHandle: string;
+    credentialId: string;
+    token?: string;
+    useCookies?: boolean;
+  }) {
+    try {
+      const result = await this.api.getAuthenticators({token, useCookies});
+
+      if (!Array.isArray(result)) {
+        if (this.enableLogging) {
+          console.warn("[Authsignal] Could not fetch authenticators for passkey sync", result);
+        }
+        return;
+      }
+
+      const credentialIds = result
+        .filter(
+          (a): a is Authenticator & {webauthnCredential: {credentialId: string}} =>
+            a.verificationMethod === VerificationMethod.PASSKEY && Boolean(a.webauthnCredential?.credentialId)
+        )
+        .map((a) => a.webauthnCredential.credentialId);
+
+      await signalAllAcceptedCredentials(
+        {rpId, userId: userHandle, credentialIds: Array.from(new Set([...credentialIds, credentialId]))},
+        this.enableLogging
+      );
+    } catch (e) {
+      if (this.enableLogging) {
+        console.warn("[Authsignal] Passkey sync failed", e);
+      }
+    }
+  }
+
+  private removeCredentialFromLocalCache(credentialId: string) {
+    const storedCredentials = localStorage.getItem(this.passkeyLocalStorageKey);
+    if (!storedCredentials) return;
+
+    let credentialsMap: Record<string, string[]>;
+    try {
+      credentialsMap = JSON.parse(storedCredentials);
+    } catch {
+      return;
+    }
+
+    let changed = false;
+    for (const userId of Object.keys(credentialsMap)) {
+      const filtered = credentialsMap[userId].filter((id) => id !== credentialId);
+      if (filtered.length !== credentialsMap[userId].length) {
+        credentialsMap[userId] = filtered;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      localStorage.setItem(this.passkeyLocalStorageKey, JSON.stringify(credentialsMap));
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,7 @@ export enum ErrorCode {
   network_error = "network_error",
   too_many_requests = "too_many_requests",
   invalid_credential = "invalid_credential",
+  unknown_credential = "unknown_credential",
 }
 
 export type AuthsignalResponse<T> = {

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -1,0 +1,216 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+const webAuthnMocks = vi.hoisted(() => ({
+  startAuthentication: vi.fn(),
+  startRegistration: vi.fn(),
+}));
+
+vi.mock("@simplewebauthn/browser", () => ({
+  startAuthentication: webAuthnMocks.startAuthentication,
+  startRegistration: webAuthnMocks.startRegistration,
+  WebAuthnError: class WebAuthnError extends Error {
+    code?: string;
+  },
+}));
+
+import {VerificationMethod} from "../src/api/types/shared";
+import {Passkey} from "../src/passkey";
+import {ErrorCode} from "../src/types";
+
+const baseUrl = "https://api.example.com";
+
+const authenticationResponse = {
+  id: "current-credential-id",
+  rawId: "current-credential-id",
+  response: {
+    userHandle: "user-handle",
+    clientDataJSON: "client-data",
+    authenticatorData: "authenticator-data",
+    signature: "signature",
+  },
+  authenticatorAttachment: "platform",
+  clientExtensionResults: {},
+  type: "public-key",
+};
+
+function createPasskey({enableLogging = false}: {enableLogging?: boolean} = {}) {
+  return new Passkey({
+    baseUrl,
+    tenantId: "tenant-id",
+    anonymousId: "device-id",
+    enableLogging,
+  });
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    statusText: "OK",
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function authenticationOptionsResponse() {
+  return {
+    challengeId: "challenge-id",
+    options: {
+      challenge: "challenge",
+      rpId: "example.com",
+      allowCredentials: [],
+    },
+  };
+}
+
+function passkeyAuthenticator(credentialId: string) {
+  return {
+    userAuthenticatorId: `authenticator-${credentialId}`,
+    verificationMethod: VerificationMethod.PASSKEY,
+    createdAt: "2026-05-19T00:00:00.000Z",
+    webauthnCredential: {
+      credentialId,
+    },
+  };
+}
+
+function setupFetch() {
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function setupSignalApi() {
+  const signalAllAcceptedCredentials = vi.fn().mockResolvedValue(undefined);
+  const signalUnknownCredential = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(window, "PublicKeyCredential", {
+    configurable: true,
+    value: {
+      signalAllAcceptedCredentials,
+      signalUnknownCredential,
+    },
+  });
+
+  return {signalAllAcceptedCredentials, signalUnknownCredential};
+}
+
+async function flushBackgroundSync() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("Passkey passkey sync", () => {
+  const originalPublicKeyCredential = window.PublicKeyCredential;
+
+  beforeEach(() => {
+    webAuthnMocks.startAuthentication.mockReset();
+    webAuthnMocks.startRegistration.mockReset();
+    webAuthnMocks.startAuthentication.mockResolvedValue(authenticationResponse);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+  });
+
+  it("includes the just-used credential when signaling accepted credentials", async () => {
+    const fetchMock = setupFetch();
+    const {signalAllAcceptedCredentials} = setupSignalApi();
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()))
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, accessToken: "access-token", userId: "user-id"}))
+      .mockResolvedValueOnce(jsonResponse([passkeyAuthenticator("server-credential-id")]));
+
+    await createPasskey().signIn();
+    await flushBackgroundSync();
+
+    expect(signalAllAcceptedCredentials).toHaveBeenCalledWith({
+      rpId: "example.com",
+      userId: "user-handle",
+      allAcceptedCredentialIds: ["server-credential-id", "current-credential-id"],
+    });
+  });
+
+  it("uses cookies when syncing after a cookie-backed sign-in", async () => {
+    const fetchMock = setupFetch();
+    const {signalAllAcceptedCredentials} = setupSignalApi();
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()))
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, userId: "user-id"}))
+      .mockResolvedValueOnce(jsonResponse([passkeyAuthenticator("current-credential-id")]));
+
+    await createPasskey().signIn({useCookies: true});
+    await flushBackgroundSync();
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      `${baseUrl}/client/user-authenticators`,
+      expect.objectContaining({credentials: "include"})
+    );
+    expect(signalAllAcceptedCredentials).toHaveBeenCalledWith({
+      rpId: "example.com",
+      userId: "user-handle",
+      allAcceptedCredentialIds: ["current-credential-id"],
+    });
+  });
+
+  it("does not signal an unknown credential for a generic invalid credential error", async () => {
+    const fetchMock = setupFetch();
+    const {signalUnknownCredential} = setupSignalApi();
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse())).mockResolvedValueOnce(
+      jsonResponse({
+        error: "Invalid credential",
+        errorCode: ErrorCode.invalid_credential,
+      })
+    );
+
+    const result = await createPasskey().signIn();
+
+    expect(result.errorCode).toBe(ErrorCode.invalid_credential);
+    expect(signalUnknownCredential).not.toHaveBeenCalled();
+  });
+
+  it("signals an unknown credential for a specific unknown credential error", async () => {
+    const fetchMock = setupFetch();
+    const {signalUnknownCredential} = setupSignalApi();
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse())).mockResolvedValueOnce(
+      jsonResponse({
+        error: "Unknown credential",
+        errorCode: ErrorCode.unknown_credential,
+      })
+    );
+
+    const result = await createPasskey().signIn();
+
+    expect(result.errorCode).toBe(ErrorCode.unknown_credential);
+    expect(signalUnknownCredential).toHaveBeenCalledWith({
+      rpId: "example.com",
+      credentialId: "current-credential-id",
+    });
+  });
+
+  it("contains background sync failures after the SDK response is returned", async () => {
+    const fetchMock = setupFetch();
+    setupSignalApi();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()))
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, accessToken: "access-token", userId: "user-id"}))
+      .mockRejectedValueOnce(new Error("Network failed"));
+
+    const result = await createPasskey({enableLogging: true}).signIn();
+    await flushBackgroundSync();
+
+    expect(result.data?.isVerified).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith("[Authsignal] Passkey sync failed", expect.any(Error));
+  });
+});


### PR DESCRIPTION

### New Features
- Sync passkeys with the browser/OS credential manager via the WebAuthn Signal API on successful `signIn` and `signUp`, so deleted passkeys are pruned from the user's device.

### Checklist
- [x] Version bumped
- [ ] Documentation updated 