### PR TITLE
Use npm trusted publishing for releases

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -20,18 +20,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
+      - run: npm install -g npm@latest
       - run: npm install
       - run: npm test
       - run: npm run build
       - run: npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Configure `release-package.yml` to use npm's OIDC-based trusted publishing (per https://docs.npmjs.com/trusted-publishers)
- Add `id-token: write` permission, drop unused `packages: write`
- Upgrade npm to latest (need >= 11.5.1) before publishing
- Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` env vars — no longer needed with OIDC

Trusted publishing was already enabled for this workflow on the npm side; this updates the workflow to match.

`release-dev.yml` is intentionally unchanged — it still uses the npm token.

## Test plan
- [ ] Cut a release and confirm the publish job succeeds via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)