### PR TITLE
support immediate mediation in passkeys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/browser",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/types/passkey.ts
+++ b/src/api/types/passkey.ts
@@ -2,6 +2,7 @@ import {
   AuthenticationResponseJSON,
   AuthenticatorAttachment,
   PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
 } from "@simplewebauthn/browser";
 import {Authenticator} from "./shared";
@@ -24,7 +25,7 @@ export type AuthenticationOptsRequest = {
 };
 
 export type AuthenticationOptsResponse = {
-  options: PublicKeyCredentialCreationOptionsJSON;
+  options: PublicKeyCredentialRequestOptionsJSON;
   challengeId?: string;
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,6 +105,10 @@ export function handleApiResponse<T>({response, enableLogging}: HandleApiRespons
   }
 }
 
+export function isImmediateMediationCredentialNotFoundError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
+
 export function handleWebAuthnError(error: unknown) {
   if (error instanceof WebAuthnError && error.code === "ERROR_INVALID_RP_ID") {
     const rpId = error.message?.match(/"([^"]*)"/)?.[1] || "";

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -5,14 +5,16 @@ import {
   RegistrationResponseJSON,
   AuthenticatorAttachment,
   PublicKeyCredentialHint,
+  PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/browser";
 
 import {PasskeyApiClient} from "./api/passkey-api-client";
 import {TokenCache} from "./token-cache";
-import {handleErrorResponse, handleWebAuthnError} from "./helpers";
+import {handleErrorResponse, handleWebAuthnError, isImmediateMediationCredentialNotFoundError} from "./helpers";
 import {signalAllAcceptedCredentials, signalUnknownCredential} from "./passkey-signal";
 import {AuthsignalResponse, ErrorCode} from "./types";
 import {Authenticator, VerificationMethod} from "./api/types/shared";
+import {AuthenticationOptsResponse} from "./api/types/passkey";
 
 type PasskeyOptions = {
   baseUrl: string;
@@ -46,6 +48,7 @@ type SignInParams = {
   useCookies?: boolean;
   onVerificationStarted?: () => unknown;
   syncCredentials?: boolean;
+  preferImmediatelyAvailableCredentials?: boolean;
 };
 
 type SignInResponse = {
@@ -59,7 +62,16 @@ type SignInResponse = {
 };
 
 type PublicKeyCredentialConstructorWithCapabilities = typeof PublicKeyCredential & {
-  getClientCapabilities?: () => Promise<{conditionalCreate?: boolean}>;
+  getClientCapabilities?: () => Promise<{conditionalCreate?: boolean; immediateGet?: boolean}>;
+  parseRequestOptionsFromJSON?: (options: PublicKeyCredentialRequestOptionsJSON) => PublicKeyCredentialRequestOptions;
+};
+
+type PublicKeyCredentialWithToJSON = PublicKeyCredential & {
+  toJSON: () => AuthenticationResponseJSON;
+};
+
+type ImmediateCredentialRequestOptions = CredentialRequestOptions & {
+  uiMode: "immediate";
 };
 
 let autofillRequestPending = false;
@@ -174,6 +186,8 @@ export class Passkey {
   }
 
   async signIn(params?: SignInParams): Promise<AuthsignalResponse<SignInResponse>> {
+    const preferImmediatelyAvailableCredentials = Boolean(params?.preferImmediatelyAvailableCredentials);
+
     if (params?.token && params.autofill) {
       throw new Error("autofill is not supported when providing a token");
     }
@@ -182,7 +196,18 @@ export class Passkey {
       throw new Error("action is not supported when providing a token");
     }
 
+    if (preferImmediatelyAvailableCredentials && params?.autofill) {
+      throw new Error("autofill is not supported when using immediate UI mode");
+    }
+
     const syncCredentials = params?.syncCredentials ?? true;
+
+    if (preferImmediatelyAvailableCredentials && !(await this.doesBrowserSupportImmediateMediation())) {
+      return this.handleClientErrorResponse(
+        ErrorCode.immediate_mediation_not_supported,
+        "Immediate mediation is not supported by this browser."
+      );
+    }
 
     if (params?.autofill) {
       if (autofillRequestPending) {
@@ -218,10 +243,29 @@ export class Passkey {
     }
 
     try {
-      const authenticationResponse = await startAuthentication({
-        optionsJSON: optionsResponse.options,
-        useBrowserAutofill: params?.autofill,
-      });
+      let authenticationResponse: AuthenticationResponseJSON;
+
+      if (preferImmediatelyAvailableCredentials) {
+        try {
+          authenticationResponse = await this.getImmediateMediationCredential(optionsResponse.options);
+        } catch (e) {
+          if (isImmediateMediationCredentialNotFoundError(e)) {
+            autofillRequestPending = false;
+
+            return this.handleClientErrorResponse(
+              ErrorCode.credential_not_found,
+              "No immediately available passkey credentials were found."
+            );
+          }
+
+          throw e;
+        }
+      } else {
+        authenticationResponse = await startAuthentication({
+          optionsJSON: optionsResponse.options,
+          useBrowserAutofill: params?.autofill,
+        });
+      }
 
       if (params?.onVerificationStarted) {
         params.onVerificationStarted();
@@ -364,6 +408,58 @@ export class Passkey {
     }
 
     return false;
+  }
+
+  private async doesBrowserSupportImmediateMediation() {
+    const publicKeyCredential = window.PublicKeyCredential as
+      | PublicKeyCredentialConstructorWithCapabilities
+      | undefined;
+
+    if (publicKeyCredential?.getClientCapabilities) {
+      const capabilities = await publicKeyCredential.getClientCapabilities();
+      return Boolean(capabilities.immediateGet);
+    }
+
+    return false;
+  }
+
+  private async getImmediateMediationCredential(
+    optionsJSON: AuthenticationOptsResponse["options"]
+  ): Promise<AuthenticationResponseJSON> {
+    const publicKeyCredential = window.PublicKeyCredential as PublicKeyCredentialConstructorWithCapabilities;
+
+    if (!publicKeyCredential.parseRequestOptionsFromJSON) {
+      throw new Error("IMMEDIATE_MEDIATION_NOT_SUPPORTED");
+    }
+
+    const immediateOptionsJSON: PublicKeyCredentialRequestOptionsJSON = {
+      ...optionsJSON,
+      allowCredentials: [],
+    };
+
+    const publicKey = publicKeyCredential.parseRequestOptionsFromJSON(immediateOptionsJSON);
+
+    const credential = (await navigator.credentials.get({
+      publicKey,
+      uiMode: "immediate",
+    } as ImmediateCredentialRequestOptions)) as PublicKeyCredentialWithToJSON | null;
+
+    if (!credential) {
+      throw new DOMException("No immediately available credentials were found.", "NotAllowedError");
+    }
+
+    return credential.toJSON();
+  }
+
+  private handleClientErrorResponse(
+    errorCode: ErrorCode,
+    errorDescription: string
+  ): AuthsignalResponse<SignInResponse> {
+    return {
+      error: errorDescription,
+      errorCode,
+      errorDescription,
+    };
   }
 
   private getAuthOptionsRpId(options: unknown): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,8 @@ export enum ErrorCode {
   too_many_requests = "too_many_requests",
   invalid_credential = "invalid_credential",
   unknown_credential = "unknown_credential",
+  credential_not_found = "credential_not_found",
+  immediate_mediation_not_supported = "immediate_mediation_not_supported",
 }
 
 export type AuthsignalResponse<T> = {

--- a/test/api-helpers.test.ts
+++ b/test/api-helpers.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from "vitest";
+
+import {buildHeaders} from "../src/api/helpers";
+
+describe("buildHeaders", () => {
+  it("builds browser-safe headers without custom SDK metadata headers", () => {
+    const headers = buildHeaders({tenantId: "tenant-id"});
+
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: `Basic ${window.btoa(encodeURIComponent("tenant-id"))}`,
+    });
+    expect(Object.keys(headers).some((header) => header.toLowerCase().startsWith("x-authsignal-"))).toBe(false);
+  });
+
+  it("uses bearer authorization when a token is provided", () => {
+    expect(buildHeaders({tenantId: "tenant-id", token: "token"})).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer token",
+    });
+  });
+});

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -50,13 +50,14 @@ function jsonResponse(body: unknown) {
   } as unknown as Response;
 }
 
-function authenticationOptionsResponse() {
+function authenticationOptionsResponse(options: Record<string, unknown> = {}) {
   return {
     challengeId: "challenge-id",
     options: {
       challenge: "challenge",
       rpId: "example.com",
       allowCredentials: [],
+      ...options,
     },
   };
 }
@@ -212,5 +213,108 @@ describe("Passkey passkey sync", () => {
 
     expect(result.data?.isVerified).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith("[Authsignal] Passkey sync failed", expect.any(Error));
+  });
+});
+
+function setupImmediateApi({immediateGet = true}: {immediateGet?: boolean} = {}) {
+  const getClientCapabilities = vi.fn().mockResolvedValue({immediateGet});
+  const parseRequestOptionsFromJSON = vi.fn((options: unknown) => options);
+
+  Object.defineProperty(window, "PublicKeyCredential", {
+    configurable: true,
+    value: {
+      getClientCapabilities,
+      parseRequestOptionsFromJSON,
+      signalAllAcceptedCredentials: vi.fn().mockResolvedValue(undefined),
+      signalUnknownCredential: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+
+  const credentialsGet = vi.fn();
+  Object.defineProperty(navigator, "credentials", {
+    configurable: true,
+    value: {get: credentialsGet},
+  });
+
+  return {getClientCapabilities, parseRequestOptionsFromJSON, credentialsGet};
+}
+
+describe("Passkey immediate UI mode", () => {
+  const originalPublicKeyCredential = window.PublicKeyCredential;
+
+  beforeEach(() => {
+    webAuthnMocks.startAuthentication.mockReset();
+    webAuthnMocks.startAuthentication.mockResolvedValue(authenticationResponse);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+  });
+
+  it("signs in using immediate UI mode when a credential is available", async () => {
+    const fetchMock = setupFetch();
+    const {parseRequestOptionsFromJSON, credentialsGet} = setupImmediateApi();
+    credentialsGet.mockResolvedValue({toJSON: () => authenticationResponse});
+    const optionsResponse = authenticationOptionsResponse({
+      allowCredentials: [{id: "known-credential-id", type: "public-key"}],
+    });
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(optionsResponse))
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, accessToken: "access-token", userId: "user-id"}));
+
+    const result = await createPasskey().signIn({
+      preferImmediatelyAvailableCredentials: true,
+      syncCredentials: false,
+    });
+
+    expect(result.data?.isVerified).toBe(true);
+    expect(result.data?.token).toBe("access-token");
+    expect(webAuthnMocks.startAuthentication).not.toHaveBeenCalled();
+    expect(parseRequestOptionsFromJSON).toHaveBeenCalledWith({...optionsResponse.options, allowCredentials: []});
+    expect(credentialsGet).toHaveBeenCalledWith(expect.objectContaining({uiMode: "immediate"}));
+    expect(credentialsGet.mock.calls[0][0]).not.toHaveProperty("mediation");
+  });
+
+  it("returns credential_not_found when no credential is immediately available", async () => {
+    const fetchMock = setupFetch();
+    const {credentialsGet} = setupImmediateApi();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    credentialsGet.mockRejectedValue(new DOMException("No credentials", "NotAllowedError"));
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()));
+
+    const result = await createPasskey({enableLogging: true}).signIn({preferImmediatelyAvailableCredentials: true});
+
+    expect(result.errorCode).toBe(ErrorCode.credential_not_found);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns immediate_mediation_not_supported when the browser lacks the capability", async () => {
+    const fetchMock = setupFetch();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    setupImmediateApi({immediateGet: false});
+
+    const result = await createPasskey({enableLogging: true}).signIn({preferImmediatelyAvailableCredentials: true});
+
+    expect(result.errorCode).toBe(ErrorCode.immediate_mediation_not_supported);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when immediate UI mode is combined with autofill", async () => {
+    setupImmediateApi();
+
+    await expect(createPasskey().signIn({preferImmediatelyAvailableCredentials: true, autofill: true})).rejects.toThrow(
+      "autofill is not supported when using immediate UI mode"
+    );
   });
 });


### PR DESCRIPTION
### New Features
- Add WebAuthn immediate UI mode to `passkey.signIn()` via a new `preferImmediatelyAvailableCredentials` option.
- Adds `ErrorCode.credential_not_found` and `ErrorCode.immediate_mediation_not_supported`.


### Checklist
- [x] Version bumped