### PR TITLE
support immediate mediation in passkeys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/browser",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/types/passkey.ts
+++ b/src/api/types/passkey.ts
@@ -2,6 +2,7 @@ import {
   AuthenticationResponseJSON,
   AuthenticatorAttachment,
   PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
   RegistrationResponseJSON,
 } from "@simplewebauthn/browser";
 import {Authenticator} from "./shared";
@@ -24,7 +25,7 @@ export type AuthenticationOptsRequest = {
 };
 
 export type AuthenticationOptsResponse = {
-  options: PublicKeyCredentialCreationOptionsJSON;
+  options: PublicKeyCredentialRequestOptionsJSON;
   challengeId?: string;
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -105,6 +105,59 @@ export function handleApiResponse<T>({response, enableLogging}: HandleApiRespons
   }
 }
 
+export function isImmediateMediationCredentialNotFoundError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
+
+type IdentifyImmediateMediationAuthenticationErrorParams = {
+  error: unknown;
+  publicKey: {
+    rpId?: string;
+  };
+};
+
+export function identifyImmediateMediationAuthenticationError({
+  error,
+  publicKey,
+}: IdentifyImmediateMediationAuthenticationErrorParams) {
+  const errorName = getErrorName(error);
+
+  if (!errorName) {
+    return error;
+  }
+
+  if (errorName === "SecurityError") {
+    const effectiveDomain = globalThis.location.hostname;
+
+    if (!isValidDomain(effectiveDomain)) {
+      return new WebAuthnError({
+        message: `${globalThis.location.hostname} is an invalid domain`,
+        code: "ERROR_INVALID_DOMAIN",
+        cause: error as Error,
+      });
+    }
+
+    if (publicKey.rpId !== effectiveDomain) {
+      return new WebAuthnError({
+        message: `The RP ID "${publicKey.rpId}" is invalid for this domain`,
+        code: "ERROR_INVALID_RP_ID",
+        cause: error as Error,
+      });
+    }
+  }
+
+  if (errorName === "UnknownError") {
+    return new WebAuthnError({
+      message:
+        "The authenticator was unable to process the specified options, or could not create a new assertion signature",
+      code: "ERROR_AUTHENTICATOR_GENERAL_ERROR",
+      cause: error as Error,
+    });
+  }
+
+  return error;
+}
+
 export function handleWebAuthnError(error: unknown) {
   if (error instanceof WebAuthnError && error.code === "ERROR_INVALID_RP_ID") {
     const rpId = error.message?.match(/"([^"]*)"/)?.[1] || "";
@@ -113,4 +166,19 @@ export function handleWebAuthnError(error: unknown) {
       `[Authsignal] The Relying Party ID "${rpId}" is invalid for this domain.\n To learn more, visit https://docs.authsignal.com/scenarios/passkeys-prebuilt-ui#defining-the-relying-party`
     );
   }
+}
+
+function isValidDomain(hostname: string) {
+  return (
+    hostname === "localhost" ||
+    /^((xn--[a-z0-9-]+|[a-z0-9]+(-[a-z0-9]+)*)\.)+([a-z]{2,}|xn--[a-z0-9-]+)$/i.test(hostname)
+  );
+}
+
+function getErrorName(error: unknown) {
+  if (error && typeof error === "object" && "name" in error && typeof error.name === "string") {
+    return error.name;
+  }
+
+  return null;
 }

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -5,14 +5,21 @@ import {
   RegistrationResponseJSON,
   AuthenticatorAttachment,
   PublicKeyCredentialHint,
+  PublicKeyCredentialRequestOptionsJSON,
 } from "@simplewebauthn/browser";
 
 import {PasskeyApiClient} from "./api/passkey-api-client";
 import {TokenCache} from "./token-cache";
-import {handleErrorResponse, handleWebAuthnError} from "./helpers";
+import {
+  handleErrorResponse,
+  handleWebAuthnError,
+  identifyImmediateMediationAuthenticationError,
+  isImmediateMediationCredentialNotFoundError,
+} from "./helpers";
 import {signalAllAcceptedCredentials, signalUnknownCredential} from "./passkey-signal";
 import {AuthsignalResponse, ErrorCode} from "./types";
 import {Authenticator, VerificationMethod} from "./api/types/shared";
+import {AuthenticationOptsResponse} from "./api/types/passkey";
 
 type PasskeyOptions = {
   baseUrl: string;
@@ -46,6 +53,7 @@ type SignInParams = {
   useCookies?: boolean;
   onVerificationStarted?: () => unknown;
   syncCredentials?: boolean;
+  preferImmediatelyAvailableCredentials?: boolean;
 };
 
 type SignInResponse = {
@@ -59,7 +67,16 @@ type SignInResponse = {
 };
 
 type PublicKeyCredentialConstructorWithCapabilities = typeof PublicKeyCredential & {
-  getClientCapabilities?: () => Promise<{conditionalCreate?: boolean}>;
+  getClientCapabilities?: () => Promise<{conditionalCreate?: boolean; immediateGet?: boolean}>;
+  parseRequestOptionsFromJSON?: (options: PublicKeyCredentialRequestOptionsJSON) => PublicKeyCredentialRequestOptions;
+};
+
+type PublicKeyCredentialWithToJSON = PublicKeyCredential & {
+  toJSON: () => AuthenticationResponseJSON;
+};
+
+type ImmediateCredentialRequestOptions = CredentialRequestOptions & {
+  uiMode: "immediate";
 };
 
 let autofillRequestPending = false;
@@ -174,6 +191,8 @@ export class Passkey {
   }
 
   async signIn(params?: SignInParams): Promise<AuthsignalResponse<SignInResponse>> {
+    const preferImmediatelyAvailableCredentials = Boolean(params?.preferImmediatelyAvailableCredentials);
+
     if (params?.token && params.autofill) {
       throw new Error("autofill is not supported when providing a token");
     }
@@ -182,7 +201,18 @@ export class Passkey {
       throw new Error("action is not supported when providing a token");
     }
 
+    if (preferImmediatelyAvailableCredentials && params?.autofill) {
+      throw new Error("autofill is not supported when using immediate UI mode");
+    }
+
     const syncCredentials = params?.syncCredentials ?? true;
+
+    if (preferImmediatelyAvailableCredentials && !(await this.doesBrowserSupportImmediateMediation())) {
+      return this.handleClientErrorResponse(
+        ErrorCode.immediate_mediation_not_supported,
+        "Immediate UI mode is not supported by this browser."
+      );
+    }
 
     if (params?.autofill) {
       if (autofillRequestPending) {
@@ -218,10 +248,12 @@ export class Passkey {
     }
 
     try {
-      const authenticationResponse = await startAuthentication({
-        optionsJSON: optionsResponse.options,
-        useBrowserAutofill: params?.autofill,
-      });
+      const authenticationResponse = preferImmediatelyAvailableCredentials
+        ? await this.getImmediateMediationCredential(optionsResponse.options)
+        : await startAuthentication({
+            optionsJSON: optionsResponse.options,
+            useBrowserAutofill: params?.autofill,
+          });
 
       if (params?.onVerificationStarted) {
         params.onVerificationStarted();
@@ -294,9 +326,20 @@ export class Passkey {
     } catch (e) {
       autofillRequestPending = false;
 
-      handleWebAuthnError(e);
+      if (preferImmediatelyAvailableCredentials && isImmediateMediationCredentialNotFoundError(e)) {
+        return this.handleClientErrorResponse(
+          ErrorCode.credential_not_found,
+          "No immediately available passkey credentials were found."
+        );
+      }
 
-      throw e;
+      const error = preferImmediatelyAvailableCredentials
+        ? identifyImmediateMediationAuthenticationError({error: e, publicKey: optionsResponse.options})
+        : e;
+
+      handleWebAuthnError(error);
+
+      throw error;
     }
   }
 
@@ -364,6 +407,61 @@ export class Passkey {
     }
 
     return false;
+  }
+
+  private async doesBrowserSupportImmediateMediation() {
+    const publicKeyCredential = window.PublicKeyCredential as
+      | PublicKeyCredentialConstructorWithCapabilities
+      | undefined;
+
+    if (!publicKeyCredential?.getClientCapabilities || !publicKeyCredential.parseRequestOptionsFromJSON) {
+      return false;
+    }
+
+    try {
+      const capabilities = await publicKeyCredential.getClientCapabilities();
+
+      return Boolean(capabilities.immediateGet && navigator.credentials?.get);
+    } catch {
+      return false;
+    }
+  }
+
+  private async getImmediateMediationCredential(
+    optionsJSON: AuthenticationOptsResponse["options"]
+  ): Promise<AuthenticationResponseJSON> {
+    const publicKeyCredential = window.PublicKeyCredential as PublicKeyCredentialConstructorWithCapabilities;
+
+    const publicKey = publicKeyCredential.parseRequestOptionsFromJSON?.({
+      ...optionsJSON,
+      allowCredentials: [],
+    });
+
+    if (!publicKey) {
+      throw new Error("IMMEDIATE_MEDIATION_NOT_SUPPORTED");
+    }
+
+    const credential = (await navigator.credentials.get({
+      publicKey,
+      uiMode: "immediate",
+    } as ImmediateCredentialRequestOptions)) as PublicKeyCredentialWithToJSON | null;
+
+    if (!credential) {
+      throw new DOMException("No immediately available credentials were found.", "NotAllowedError");
+    }
+
+    return credential.toJSON();
+  }
+
+  private handleClientErrorResponse(
+    errorCode: ErrorCode,
+    errorDescription: string
+  ): AuthsignalResponse<SignInResponse> {
+    return {
+      error: errorDescription,
+      errorCode,
+      errorDescription,
+    };
   }
 
   private getAuthOptionsRpId(options: unknown): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,8 @@ export enum ErrorCode {
   too_many_requests = "too_many_requests",
   invalid_credential = "invalid_credential",
   unknown_credential = "unknown_credential",
+  credential_not_found = "credential_not_found",
+  immediate_mediation_not_supported = "immediate_mediation_not_supported",
 }
 
 export type AuthsignalResponse<T> = {

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -10,6 +10,12 @@ vi.mock("@simplewebauthn/browser", () => ({
   startRegistration: webAuthnMocks.startRegistration,
   WebAuthnError: class WebAuthnError extends Error {
     code?: string;
+
+    constructor({message, code, cause, name}: {message: string; code: string; cause: Error; name?: string}) {
+      super(message);
+      this.name = name ?? cause.name;
+      this.code = code;
+    }
   },
 }));
 
@@ -50,13 +56,14 @@ function jsonResponse(body: unknown) {
   } as unknown as Response;
 }
 
-function authenticationOptionsResponse() {
+function authenticationOptionsResponse(options: Record<string, unknown> = {}) {
   return {
     challengeId: "challenge-id",
     options: {
       challenge: "challenge",
       rpId: "example.com",
       allowCredentials: [],
+      ...options,
     },
   };
 }
@@ -212,5 +219,205 @@ describe("Passkey passkey sync", () => {
 
     expect(result.data?.isVerified).toBe(true);
     expect(warnSpy).toHaveBeenCalledWith("[Authsignal] Passkey sync failed", expect.any(Error));
+  });
+});
+
+function setupImmediateApi({immediateGet = true}: {immediateGet?: boolean} = {}) {
+  const getClientCapabilities = vi.fn().mockResolvedValue({immediateGet});
+  const parseRequestOptionsFromJSON = vi.fn((options: unknown) => options);
+
+  Object.defineProperty(window, "PublicKeyCredential", {
+    configurable: true,
+    value: {
+      getClientCapabilities,
+      parseRequestOptionsFromJSON,
+      signalAllAcceptedCredentials: vi.fn().mockResolvedValue(undefined),
+      signalUnknownCredential: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+
+  const credentialsGet = vi.fn();
+  Object.defineProperty(navigator, "credentials", {
+    configurable: true,
+    value: {get: credentialsGet},
+  });
+
+  return {getClientCapabilities, parseRequestOptionsFromJSON, credentialsGet};
+}
+
+describe("Passkey immediate UI mode", () => {
+  const originalPublicKeyCredential = window.PublicKeyCredential;
+  const originalNavigatorCredentials = navigator.credentials;
+
+  beforeEach(() => {
+    webAuthnMocks.startAuthentication.mockReset();
+    webAuthnMocks.startRegistration.mockReset();
+    webAuthnMocks.startAuthentication.mockResolvedValue(authenticationResponse);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: originalNavigatorCredentials,
+    });
+  });
+
+  it("signs in using immediate UI mode when a credential is available", async () => {
+    const fetchMock = setupFetch();
+    const {parseRequestOptionsFromJSON, credentialsGet} = setupImmediateApi();
+    const optionsResponse = authenticationOptionsResponse({
+      allowCredentials: [{id: "known-credential-id", type: "public-key"}],
+    });
+    credentialsGet.mockResolvedValue({toJSON: () => authenticationResponse});
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(optionsResponse))
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, accessToken: "access-token", userId: "user-id"}));
+
+    const result = await createPasskey().signIn({
+      preferImmediatelyAvailableCredentials: true,
+      syncCredentials: false,
+    });
+
+    expect(result.data?.isVerified).toBe(true);
+    expect(result.data?.token).toBe("access-token");
+    expect(webAuthnMocks.startAuthentication).not.toHaveBeenCalled();
+    expect(parseRequestOptionsFromJSON).toHaveBeenCalledWith({...optionsResponse.options, allowCredentials: []});
+    expect(credentialsGet).toHaveBeenCalledWith(expect.objectContaining({uiMode: "immediate"}));
+    expect(credentialsGet.mock.calls[0][0]).not.toHaveProperty("mediation");
+  });
+
+  it("returns credential_not_found when no credential is immediately available", async () => {
+    const fetchMock = setupFetch();
+    const {credentialsGet} = setupImmediateApi();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    credentialsGet.mockRejectedValue(new DOMException("No credentials", "NotAllowedError"));
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()));
+
+    const result = await createPasskey({enableLogging: true}).signIn({
+      preferImmediatelyAvailableCredentials: true,
+    });
+
+    expect(result.errorCode).toBe(ErrorCode.credential_not_found);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a WebAuthnError for immediate UI mode security errors", async () => {
+    const fetchMock = setupFetch();
+    const {credentialsGet} = setupImmediateApi();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    credentialsGet.mockRejectedValue(new DOMException("Invalid RP ID", "SecurityError"));
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse({rpId: "example.com"})));
+
+    await expect(
+      createPasskey().signIn({
+        preferImmediatelyAvailableCredentials: true,
+      })
+    ).rejects.toMatchObject({
+      code: "ERROR_INVALID_RP_ID",
+      message: 'The RP ID "example.com" is invalid for this domain',
+      name: "SecurityError",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('The Relying Party ID "example.com" is invalid for this domain.')
+    );
+  });
+
+  it("throws a WebAuthnError for immediate UI mode unknown errors", async () => {
+    const fetchMock = setupFetch();
+    const {credentialsGet} = setupImmediateApi();
+    credentialsGet.mockRejectedValue(new DOMException("Unknown", "UnknownError"));
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(authenticationOptionsResponse()));
+
+    await expect(
+      createPasskey().signIn({
+        preferImmediatelyAvailableCredentials: true,
+      })
+    ).rejects.toMatchObject({
+      code: "ERROR_AUTHENTICATOR_GENERAL_ERROR",
+      message:
+        "The authenticator was unable to process the specified options, or could not create a new assertion signature",
+      name: "UnknownError",
+    });
+  });
+
+  it("returns immediate_mediation_not_supported when the browser lacks the capability", async () => {
+    const fetchMock = setupFetch();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    setupImmediateApi({immediateGet: false});
+
+    const result = await createPasskey({enableLogging: true}).signIn({
+      preferImmediatelyAvailableCredentials: true,
+    });
+
+    expect(result.errorCode).toBe(ErrorCode.immediate_mediation_not_supported);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns immediate_mediation_not_supported when request option parsing is unavailable", async () => {
+    const fetchMock = setupFetch();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: {
+        getClientCapabilities: vi.fn().mockResolvedValue({immediateGet: true}),
+      },
+    });
+
+    const result = await createPasskey({enableLogging: true}).signIn({
+      preferImmediatelyAvailableCredentials: true,
+    });
+
+    expect(result.errorCode).toBe(ErrorCode.immediate_mediation_not_supported);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns immediate_mediation_not_supported when capability detection fails", async () => {
+    const fetchMock = setupFetch();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: {
+        getClientCapabilities: vi.fn().mockRejectedValue(new Error("Detection failed")),
+        parseRequestOptionsFromJSON: vi.fn(),
+      },
+    });
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {get: vi.fn()},
+    });
+
+    const result = await createPasskey({enableLogging: true}).signIn({
+      preferImmediatelyAvailableCredentials: true,
+    });
+
+    expect(result.errorCode).toBe(ErrorCode.immediate_mediation_not_supported);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when immediate UI mode is combined with autofill", async () => {
+    setupImmediateApi();
+
+    await expect(createPasskey().signIn({preferImmediatelyAvailableCredentials: true, autofill: true})).rejects.toThrow(
+      "autofill is not supported when using immediate UI mode"
+    );
   });
 });


### PR DESCRIPTION
### New Features
- Add WebAuthn immediate UI mode to `passkey.signIn()` via a new `preferImmediatelyAvailableCredentials` option.
- Adds `ErrorCode.credential_not_found` and `ErrorCode.immediate_mediation_not_supported`.


### Checklist
- [x] Version bumped