### PR TITLE
Spike: Secure Payment Confirmation (SPC) sign-in for passkeys / 3DS (NOT FOR MERGE)

### DIFF
--- a/src/api/types/passkey.ts
+++ b/src/api/types/passkey.ts
@@ -70,8 +70,20 @@ export type ChallengeRequest = {
   useCookies?: boolean;
 };
 
+// SPC SPIKE: per-transaction payment data returned alongside the challenge when the
+// action has Secure Payment Confirmation enabled. Display-only `instrument` — never a PAN.
+export type SpcChallengeData = {
+  payeeName?: string;
+  payeeOrigin?: string;
+  amount: string; // decimal string, e.g. "42.00"
+  currency: string; // ISO-4217, e.g. "USD"
+  instrument: {displayName: string; icon: string};
+  credentialIds: string[];
+};
+
 export type ChallengeResponse = {
   challengeId: string;
+  spc?: SpcChallengeData; // SPC SPIKE
 };
 
 export type ErrorResponse = {

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -343,6 +343,132 @@ export class Passkey {
     }
   }
 
+  // SPC SPIKE: Secure Payment Confirmation sign-in for a 3DS transaction.
+  // See authsignal-serverless/docs/rfc-secure-payment-confirmation-3ds.md (PR #2643).
+  //
+  // Unlike signIn(), this does NOT use startAuthentication()/navigator.credentials.get()
+  // — the SimpleWebAuthn browser package has no SPC support. SPC runs through the
+  // PaymentRequest API, which renders the native "Pay $X to <payee>" dialog before the
+  // biometric prompt and bakes the transaction into the assertion (type "payment.get").
+  // The resulting assertion is posted to the SAME verify endpoint as a normal passkey.
+  async signInWithPaymentConfirmation(params: {action: string}): Promise<AuthsignalResponse<SignInResponse>> {
+    const challengeResponse = await this.api.challenge({action: params.action});
+
+    if ("error" in challengeResponse) {
+      return handleErrorResponse({errorResponse: challengeResponse, enableLogging: this.enableLogging});
+    }
+
+    const {challengeId, spc} = challengeResponse;
+
+    if (!spc) {
+      throw new Error("SPC_NOT_ENABLED_FOR_ACTION");
+    }
+
+    const optionsResponse = await this.api.authenticationOptions({challengeId});
+
+    if ("error" in optionsResponse) {
+      return handleErrorResponse({errorResponse: optionsResponse, enableLogging: this.enableLogging});
+    }
+
+    // Graceful fallback: SPC is Chromium-only. On unsupported browsers fall back to the
+    // standard passkey ceremony so the 3DS challenge can still complete.
+    if (!(await this.isSpcAvailable())) {
+      return this.signIn({action: params.action});
+    }
+
+    const rpId = this.getAuthOptionsRpId(optionsResponse.options);
+    const {challenge} = optionsResponse.options;
+
+    try {
+      // 'secure-payment-confirmation' method data is loosely typed (PaymentMethodData.data: any).
+      const request = new PaymentRequest(
+        [
+          {
+            supportedMethods: "secure-payment-confirmation",
+            data: {
+              rpId,
+              challenge: base64UrlToBuffer(challenge),
+              credentialIds: spc.credentialIds.map(base64UrlToBuffer),
+              instrument: spc.instrument,
+              payeeName: spc.payeeName,
+              payeeOrigin: spc.payeeOrigin,
+              timeout: 60000,
+            },
+          },
+        ],
+        {total: {label: "Total", amount: {currency: spc.currency, value: spc.amount}}}
+      );
+
+      const paymentResponse = await request.show();
+      // The PaymentResponse carries the WebAuthn assertion in `details`.
+      const credential = paymentResponse.details as PublicKeyCredential;
+      await paymentResponse.complete("success");
+
+      const authenticationResponse = toAuthenticationResponseJSON(credential);
+
+      const verifyResponse = await this.api.verify({
+        authenticationCredential: authenticationResponse,
+        deviceId: this.anonymousId,
+        challengeId: optionsResponse.challengeId,
+      });
+
+      if ("error" in verifyResponse) {
+        return handleErrorResponse({errorResponse: verifyResponse, enableLogging: this.enableLogging});
+      }
+
+      if (verifyResponse.accessToken) {
+        this.cache.token = verifyResponse.accessToken;
+      }
+
+      const {accessToken: token, userId, userAuthenticatorId, username, userDisplayName, isVerified} = verifyResponse;
+
+      return {
+        data: {
+          isVerified,
+          token,
+          userId,
+          userAuthenticatorId,
+          username,
+          displayName: userDisplayName,
+          authenticationResponse,
+        },
+      };
+    } catch (e) {
+      handleWebAuthnError(e);
+
+      throw e;
+    }
+  }
+
+  // SPC SPIKE: feature-detect Secure Payment Confirmation (Chromium-only).
+  private async isSpcAvailable(): Promise<boolean> {
+    if (typeof window === "undefined" || !("PaymentRequest" in window)) {
+      return false;
+    }
+
+    try {
+      const request = new PaymentRequest(
+        [
+          {
+            supportedMethods: "secure-payment-confirmation",
+            data: {
+              rpId: "example.com",
+              credentialIds: [new Uint8Array(1)],
+              challenge: new Uint8Array(1),
+              instrument: {displayName: "x", icon: "https://example.com/x.png"},
+              payeeName: "x",
+            },
+          },
+        ],
+        {total: {label: "x", amount: {currency: "USD", value: "0"}}}
+      );
+
+      return await request.canMakePayment();
+    } catch {
+      return false;
+    }
+  }
+
   async isAvailableOnDevice({userId}: {userId: string}) {
     if (!userId) {
       throw new Error("userId is required");
@@ -534,4 +660,49 @@ export class Passkey {
       localStorage.setItem(this.passkeyLocalStorageKey, JSON.stringify(credentialsMap));
     }
   }
+}
+
+// SPC SPIKE: decode a base64url string (as used in WebAuthn JSON options) to an ArrayBuffer.
+// The PaymentRequest `secure-payment-confirmation` data wants BufferSources, not strings.
+function base64UrlToBuffer(base64Url: string): ArrayBuffer {
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  return buffer.buffer;
+}
+
+// SPC SPIKE: encode an ArrayBuffer to base64url for the verify request body.
+function bufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// SPC SPIKE: normalise the PublicKeyCredential returned by PaymentRequest into the
+// AuthenticationResponseJSON shape our verify endpoint already accepts. (SimpleWebAuthn's
+// startAuthentication does this internally; with the PaymentRequest path we do it ourselves.)
+function toAuthenticationResponseJSON(credential: PublicKeyCredential): AuthenticationResponseJSON {
+  const assertion = credential.response as AuthenticatorAssertionResponse;
+
+  return {
+    id: credential.id,
+    rawId: bufferToBase64Url(credential.rawId),
+    type: "public-key",
+    clientExtensionResults: credential.getClientExtensionResults(),
+    authenticatorAttachment: (credential as unknown as {authenticatorAttachment?: AuthenticatorAttachment})
+      .authenticatorAttachment,
+    response: {
+      clientDataJSON: bufferToBase64Url(assertion.clientDataJSON),
+      authenticatorData: bufferToBase64Url(assertion.authenticatorData),
+      signature: bufferToBase64Url(assertion.signature),
+      userHandle: assertion.userHandle ? bufferToBase64Url(assertion.userHandle) : undefined,
+    },
+  };
 }


### PR DESCRIPTION
### Breaking Changes
None. Additive only — new `signInWithPaymentConfirmation()` method; existing passkey flows untouched.

### New Features
⚠️ **Spike — not for merge.** Browser-SDK companion to the SPC RFC in [authsignal/authsignal-serverless#2643](https://github.com/authsignal/authsignal-serverless/pull/2643). Exists so reviewers can see the client-side shape of the changes alongside the design doc. Every change is tagged with a `// SPC SPIKE` comment.

Adds **Secure Payment Confirmation** sign-in for the **3-D Secure (3DS)** step-up flow:

- **`signInWithPaymentConfirmation({action})`** ([`src/passkey.ts`](src/passkey.ts)) — runs the SPC ceremony via the **`PaymentRequest` API** rather than `startAuthentication()`/`navigator.credentials.get()`. This is the key finding: `@simplewebauthn/browser` has **no SPC support**, so the payment dialog + assertion must be assembled manually. The browser renders the native "Pay \$X to &lt;payee&gt;" dialog, and the resulting `payment.get` assertion is posted to the **same** verify endpoint as a normal passkey.
- **`isSpcAvailable()`** feature-detection (SPC is Chromium-only) with **graceful fallback** to the standard `signIn()` passkey ceremony so 3DS still completes on Safari/Firefox.
- **base64url / `AuthenticationResponseJSON` normalisation helpers** — the conversion `startAuthentication()` would normally do internally.
- **`SpcChallengeData`** on the challenge response ([`src/api/types/passkey.ts`](src/api/types/passkey.ts)) — per-transaction payee/amount/instrument/credentialIds.

### Bug Fixes
None.

### Checklist
- [ ] Version bumped — N/A (spike, not for release)
- [ ] Documentation updated — design doc lives in the serverless RFC (#2643)

---

**What reviewers should know**
- **No PAN is handled anywhere.** SPC's `instrument` is a display-only label/icon; the card number never touches the SDK.
- Rebased onto current `main` and adapted to main's passkey API (challengeId threading, `handleErrorResponse({errorResponse, enableLogging})`, `ChallengeResponse` shape) — so the diff is just the 2 SPC files, no unrelated commits.
- Adds **zero net typecheck errors** over main's baseline (main is already red from `@simplewebauthn/browser` node_modules drift, unrelated to this spike — verified by stashing).
- Pairs with the serverless spike, which handles the `payment.get` verification + payment-field validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)