### PR TITLE
Deprecate browser passkey availability check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/browser",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "MIT",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -343,6 +343,13 @@ export class Passkey {
     }
   }
 
+  /**
+   * @deprecated This method only checks credential IDs cached by the SDK in this browser profile's
+   * localStorage and confirms they still exist on the server. It does not query the browser credential
+   * manager or prove that a passkey is available on the current device. There is no reliable browser
+   * SDK replacement for checking local passkey availability, so use product or server-side state for
+   * enrollment prompts and keep a fallback authentication option in passkey sign-in flows.
+   */
   async isAvailableOnDevice({userId}: {userId: string}) {
     if (!userId) {
       throw new Error("userId is required");


### PR DESCRIPTION
### Bug Fixes
- Clarify that `isAvailableOnDevice` only checks SDK-cached credential IDs and server state

### Checklist
- [x] Version bumped
- [ ] Documentation updated
