### PR TITLE
Fix browser SDK passkey request parity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authsignal/browser",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "MIT",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/passkey-api-client.ts
+++ b/src/api/passkey-api-client.ts
@@ -29,12 +29,15 @@ export class PasskeyApiClient {
   async registrationOptions({
     token,
     username,
+    displayName,
     authenticatorAttachment,
     useCookies,
   }: {token: string} & RegistrationOptsRequest): Promise<RegistrationOptsResponse | ErrorResponse> {
-    const body: RegistrationOptsRequest = Boolean(authenticatorAttachment)
-      ? {username, authenticatorAttachment}
-      : {username};
+    const body: RegistrationOptsRequest = {
+      username,
+      displayName,
+      ...(authenticatorAttachment !== undefined && {authenticatorAttachment}),
+    };
 
     const url = useCookies
       ? `${this.baseUrl}/client/user-authenticators/passkey/registration-options/web`

--- a/src/api/push-api-client.ts
+++ b/src/api/push-api-client.ts
@@ -1,6 +1,6 @@
 import {buildHeaders, handleTokenExpired} from "./helpers";
 import {ApiClientOptions, ErrorResponse} from "./types/shared";
-import {PushChallengeResponse, PushVerifyResponse} from "./types/push";
+import {PushChallengeResponse, PushVerifyApiResponse} from "./types/push";
 
 export class PushApiClient {
   tenantId: string;
@@ -43,7 +43,7 @@ export class PushApiClient {
   }: {
     challengeId: string;
     token: string;
-  }): Promise<PushVerifyResponse | ErrorResponse> {
+  }): Promise<PushVerifyApiResponse | ErrorResponse> {
     const body = {challengeId};
 
     const response = await fetch(`${this.baseUrl}/client/verify/push`, {

--- a/src/api/types/passkey.ts
+++ b/src/api/types/passkey.ts
@@ -10,6 +10,7 @@ import {ErrorCode} from "../../types";
 
 export type RegistrationOptsRequest = {
   username?: string;
+  displayName?: string;
   authenticatorAttachment?: AuthenticatorAttachment | null;
   useCookies?: boolean;
 };

--- a/src/api/types/push.ts
+++ b/src/api/types/push.ts
@@ -2,8 +2,14 @@ export type PushChallengeResponse = {
   challengeId: string;
 };
 
-export type PushVerifyResponse = {
+export type PushVerifyApiResponse = {
   isVerified: boolean;
   isConsumed: boolean;
   accessToken?: string;
+};
+
+export type PushVerifyResponse = {
+  isVerified: boolean;
+  isConsumed: boolean;
+  token?: string;
 };

--- a/src/qr-code.ts
+++ b/src/qr-code.ts
@@ -18,7 +18,7 @@ export type ChallengeParams = {
   custom?: Record<string, unknown>;
   /** Use REST API polling instead of WebSocket connection. Default: false */
   polling?: boolean;
-  /** The interval in milliseconds at which the QR code challenge will be polled. Default: 5 seconds (Only used when polling is true)*/
+  /** The interval in milliseconds at which the QR code challenge will be polled. Default: 3 seconds (Only used when polling is true)*/
   pollInterval?: number;
   /** The interval in milliseconds at which the QR code challenge will be refreshed. Default: 9 minutes */
   refreshInterval?: number;

--- a/test/passkey.test.ts
+++ b/test/passkey.test.ts
@@ -39,6 +39,18 @@ const authenticationResponse = {
   type: "public-key",
 };
 
+const registrationResponse = {
+  id: "new-credential-id",
+  rawId: "new-credential-id",
+  response: {
+    clientDataJSON: "client-data",
+    attestationObject: "attestation-object",
+  },
+  authenticatorAttachment: "platform",
+  clientExtensionResults: {},
+  type: "public-key",
+};
+
 function createPasskey({enableLogging = false}: {enableLogging?: boolean} = {}) {
   return new Passkey({
     baseUrl,
@@ -103,6 +115,59 @@ function setupSignalApi() {
 async function flushBackgroundSync() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
+
+describe("Passkey registration", () => {
+  const originalPublicKeyCredential = window.PublicKeyCredential;
+
+  beforeEach(() => {
+    webAuthnMocks.startAuthentication.mockReset();
+    webAuthnMocks.startRegistration.mockReset();
+    webAuthnMocks.startRegistration.mockResolvedValue(registrationResponse);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+
+    Object.defineProperty(window, "PublicKeyCredential", {
+      configurable: true,
+      value: originalPublicKeyCredential,
+    });
+  });
+
+  it("sends displayName and explicit authenticatorAttachment values when requesting registration options", async () => {
+    const fetchMock = setupFetch();
+
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          challengeId: "challenge-id",
+          options: {
+            challenge: "challenge",
+            rp: {id: "example.com", name: "Example"},
+            user: {id: "user-handle", name: "jane.smith@example.com", displayName: "Jane Smith"},
+            pubKeyCredParams: [],
+          },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({isVerified: true, accessToken: "access-token", userId: "user-id"}));
+
+    await createPasskey().signUp({
+      token: "token",
+      username: "jane.smith@example.com",
+      displayName: "Jane Smith",
+      authenticatorAttachment: null,
+      syncCredentials: false,
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string)).toEqual({
+      username: "jane.smith@example.com",
+      displayName: "Jane Smith",
+      authenticatorAttachment: null,
+    });
+  });
+});
 
 describe("Passkey passkey sync", () => {
   const originalPublicKeyCredential = window.PublicKeyCredential;


### PR DESCRIPTION
### Breaking Changes
<!-- Optional - List any backward incompatible changes -->

### New Features
<!-- Optional - List new functionality added -->

### Bug Fixes
- Send `displayName` and explicit `authenticatorAttachment: null` when requesting passkey registration options
- Align the public push verify response type with the SDK's `token` response mapping
- Update the QR code polling default comment and bump `@authsignal/browser` to `1.19.2`

### Checklist
- [x] Version bumped
- [ ] Documentation updated
