### PR TITLE
Add push delivery results and authenticator error fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@authsignal/browser",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/api/types/push.ts
+++ b/src/api/types/push.ts
@@ -1,5 +1,11 @@
+export type PushDeliveryResult = {
+  userAuthenticatorId: string;
+  errorCode?: string;
+};
+
 export type PushChallengeResponse = {
   challengeId: string;
+  deliveryResults?: PushDeliveryResult[];
 };
 
 export type PushVerifyApiResponse = {

--- a/src/api/types/shared.ts
+++ b/src/api/types/shared.ts
@@ -118,4 +118,6 @@ export type Authenticator = {
   devicePlatform?: DevicePlatform;
   username?: string;
   webauthnCredential?: WebauthnCredential;
+  erroredAt?: string;
+  errorCode?: string;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,6 @@ export * from "./types";
 export type {Authenticator, VerificationMethod, EnrollResponse, ChallengeResponse} from "./api/types/shared";
 export type {EnrollTotpResponse} from "./api/types/totp";
 export type {QrCodeChallengeResponse, QrCodeVerifyResponse} from "./api/types/qr-code";
-export type {PushChallengeResponse, PushVerifyResponse} from "./api/types/push";
+export type {PushChallengeResponse, PushDeliveryResult, PushVerifyResponse} from "./api/types/push";
 export type {WebSocketQrCodeOptions, WebSocketQrCodeResponse, ChallengeState} from "./api/types/websocket";
 export {Whatsapp} from "./whatsapp";


### PR DESCRIPTION
When a tenant sends push notifications via APNs or FCM directly, the start push challenge response now reports the per-device outcome, and failed sends are recorded on the authenticator.

## Changes

- Adds optional `deliveryResults` to `PushChallengeResponse`: the per-device outcome of `push.challenge()`, so a UI can react immediately when a device could not be reached (e.g. offer another verification method) instead of waiting for a push that will not arrive. `errorCode` is only present on failed sends and is the push provider's own code passed through as-is (e.g. `Unregistered` from APNs, `UNREGISTERED` from FCM).
- Adds optional `erroredAt` and `errorCode` to the `Authenticator` type, matching the fields now returned by the user authenticators endpoint.
- Exports the new `PushDeliveryResult` type and bumps version to 1.20.0.